### PR TITLE
Add basic resource management

### DIFF
--- a/src/main/scala/org/allenai/common/Resource.scala
+++ b/src/main/scala/org/allenai/common/Resource.scala
@@ -1,6 +1,6 @@
 package org.allenai.common
 
-package object resource {
+object Resource {
   // Allow use of methods on structural types.
   import scala.language.reflectiveCalls
 


### PR DESCRIPTION
I found the class `ResourceHandling` to be too verbose.  It couldn't originally be `Resource` because that would conflict with `type Resource` (but that's now renamed `type Closeable`).  I put it in a package object, but maybe it should be reverted to `class Resource`.
