### PR TITLE
Fix return type of Resource.using

### DIFF
--- a/src/main/scala/org/allenai/common/Resource.scala
+++ b/src/main/scala/org/allenai/common/Resource.scala
@@ -17,7 +17,7 @@ object Resource {
     * @param  f  a computation involving the supplied resource
     * @returns  the result of the computation over the resource
     */
-  def using[A <: Closeable, B](resource: A)(f: A => B) {
+  def using[A <: Closeable, B](resource: A)(f: A => B): B = {
     require(resource != null, "The supplied resource was null.")
     try {
       f(resource)


### PR DESCRIPTION
@schmmd take a look?

Return type was inferred as `Unit` due to the lack of an `=` before the block. I added the explicit return type and the equals sign.
