### PR TITLE
Make empty interval throw exceptions on undefined operations

### DIFF
--- a/core/src/main/scala/org/allenai/common/immutable/Interval.scala
+++ b/core/src/main/scala/org/allenai/common/immutable/Interval.scala
@@ -253,9 +253,9 @@ sealed class Interval private (val start: Int, val end: Int)
 
   /** The minimum index in the interval. */
   def min = {
-      require(this != empty, "empty interval")
-      start
-    }
+    require(this != empty, "empty interval")
+    start
+  }
 
   /** The maximum index in the interval. */
   def max = {

--- a/core/src/test/scala/org/allenai/common/ConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/ConfigSpec.scala
@@ -31,8 +31,7 @@ class ConfigSpec extends UnitSpec {
     "duration" -> "5 seconds",
     "uri" -> "http://www.example.com?q=hello&r=world",
     "null" -> null,
-    "object" -> Map("foo" -> "bar").asJava
-  )
+    "object" -> Map("foo" -> "bar").asJava)
 
   val testConfig = createConfig(testConfigMap)
 
@@ -88,7 +87,7 @@ class ConfigSpec extends UnitSpec {
   }
 
   it should "work for Seq[ConfigValue]" in {
-    assert((testConfig.get[Seq[ConfigValue]]("intList") map { _ map { _.unwrapped }}) ===
+    assert((testConfig.get[Seq[ConfigValue]]("intList") map { _ map { _.unwrapped } }) ===
       Some(Seq(1, 2, 3, 4)))
   }
 

--- a/core/src/test/scala/org/allenai/common/immutable/IntervalSpec.scala
+++ b/core/src/test/scala/org/allenai/common/immutable/IntervalSpec.scala
@@ -3,33 +3,33 @@
   *
   * https://github.com/knowitall/common-scala
   *
-
-Copyright (c) 2012, University of Washington
-BSD 3-clause License / BSD Modified License / New BSD License
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the University of Washington nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE UNIVERSITY OF WASHINGTON BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+  *
+  * Copyright (c) 2012, University of Washington
+  * BSD 3-clause License / BSD Modified License / New BSD License
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+  * Redistributions of source code must retain the above copyright
+  * notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+  * notice, this list of conditions and the following disclaimer in the
+  * documentation and/or other materials provided with the distribution.
+  * Neither the name of the University of Washington nor the
+  * names of its contributors may be used to endorse or promote products
+  * derived from this software without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE UNIVERSITY OF WASHINGTON BE LIABLE FOR ANY
+  * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
   */
 
 package org.allenai.common.immutable
@@ -44,84 +44,84 @@ import org.scalatest.prop.Checkers
 
 class IntervalSpec extends UnitSpec with Checkers {
   they should "border each other" in {
-      assert((Interval.open(0, 4) borders Interval.open(4, 8)) == true)
-      assert((Interval.open(4, 8) borders Interval.open(0, 4)) == true)
-      assert((Interval.open(0, 3) borders Interval.open(4, 8)) == false)
-      assert((Interval.open(4, 8) borders Interval.open(0, 3)) == false)
-      assert((Interval.empty borders Interval.open(4, 8)) == false)
-    }
+    assert((Interval.open(0, 4) borders Interval.open(4, 8)) == true)
+    assert((Interval.open(4, 8) borders Interval.open(0, 4)) == true)
+    assert((Interval.open(0, 3) borders Interval.open(4, 8)) == false)
+    assert((Interval.open(4, 8) borders Interval.open(0, 3)) == false)
+    assert((Interval.empty borders Interval.open(4, 8)) == false)
+  }
 
   they should "union properly" in {
-      assert((Interval.open(0, 4) union Interval.open(4, 8)) == (Interval.open(0, 8)))
-      intercept[IllegalArgumentException] {
-        (Interval.open(0, 4) union Interval.open(6, 8))
-      }
+    assert((Interval.open(0, 4) union Interval.open(4, 8)) == (Interval.open(0, 8)))
+    intercept[IllegalArgumentException] {
+      (Interval.open(0, 4) union Interval.open(6, 8))
     }
+  }
 
   they should "intersect properly" in {
-      assert((Interval.open(0, 4) intersect Interval.open(4, 8))  ==  (Interval.empty))
-      assert((Interval.open(0, 4) intersect Interval.open(6, 8))  ==  (Interval.empty))
-      assert((Interval.open(0, 4) intersect Interval.open(2, 6))  ==  (Interval.open(2, 4)))
-    }
+    assert((Interval.open(0, 4) intersect Interval.open(4, 8)) == (Interval.empty))
+    assert((Interval.open(0, 4) intersect Interval.open(6, 8)) == (Interval.empty))
+    assert((Interval.open(0, 4) intersect Interval.open(2, 6)) == (Interval.open(2, 4)))
+  }
 
   they should "contain properly" in {
-      assert((Interval.open(2, 3) contains 0) ==  false)
-      assert((Interval.open(2, 3) contains 1) ==  false)
-      assert((Interval.open(2, 3) contains 2) ==  true)
-      assert((Interval.open(2, 3) contains 3) ==  false)
-    }
+    assert((Interval.open(2, 3) contains 0) == false)
+    assert((Interval.open(2, 3) contains 1) == false)
+    assert((Interval.open(2, 3) contains 2) == true)
+    assert((Interval.open(2, 3) contains 3) == false)
+  }
 
   they should "shift ok" in {
-      assert((Interval.open(2, 4) shift 2)  ==  Interval.open(4, 6))
-      assert((Interval.open(2, 4) shift -2)  ==  Interval.open(0, 2))
-    }
+    assert((Interval.open(2, 4) shift 2) == Interval.open(4, 6))
+    assert((Interval.open(2, 4) shift -2) == Interval.open(0, 2))
+  }
 
   "the correct left interval" should "be determined" in {
-    assert((Interval.open(0, 4) left Interval.open(4, 8))  ==  (Interval.open(0, 4)))
-    assert((Interval.open(0, 4) left Interval.open(2, 6))  ==  (Interval.open(0, 4)))
-    assert((Interval.open(4, 8) left Interval.open(0, 4))  ==  (Interval.open(0, 4)))
-    assert((Interval.open(2, 6) left Interval.open(0, 4))  ==  (Interval.open(0, 4)))
+    assert((Interval.open(0, 4) left Interval.open(4, 8)) == (Interval.open(0, 4)))
+    assert((Interval.open(0, 4) left Interval.open(2, 6)) == (Interval.open(0, 4)))
+    assert((Interval.open(4, 8) left Interval.open(0, 4)) == (Interval.open(0, 4)))
+    assert((Interval.open(2, 6) left Interval.open(0, 4)) == (Interval.open(0, 4)))
   }
 
   "the correct right interval" should "be determined" in {
-    assert((Interval.open(0, 4) right Interval.open(4, 8))  ==  (Interval.open(4, 8)))
-    assert((Interval.open(0, 4) right Interval.open(2, 6))  ==  (Interval.open(2, 6)))
-    assert((Interval.open(4, 8) right Interval.open(0, 4))  ==  (Interval.open(4, 8)))
-    assert((Interval.open(2, 6) right Interval.open(0, 4))  ==  (Interval.open(2, 6)))
+    assert((Interval.open(0, 4) right Interval.open(4, 8)) == (Interval.open(4, 8)))
+    assert((Interval.open(0, 4) right Interval.open(2, 6)) == (Interval.open(2, 6)))
+    assert((Interval.open(4, 8) right Interval.open(0, 4)) == (Interval.open(4, 8)))
+    assert((Interval.open(2, 6) right Interval.open(0, 4)) == (Interval.open(2, 6)))
   }
 
   "leftOf" should "work" in {
-    assert((Interval.open(0, 4) leftOf Interval.open(4, 8))  == true)
-    assert((Interval.open(0, 4) leftOf Interval.open(2, 6))  == false)
-    assert((Interval.open(4, 8) leftOf Interval.open(0, 4))  == false)
-    assert((Interval.open(2, 6) leftOf Interval.open(0, 4))  == false)
+    assert((Interval.open(0, 4) leftOf Interval.open(4, 8)) == true)
+    assert((Interval.open(0, 4) leftOf Interval.open(2, 6)) == false)
+    assert((Interval.open(4, 8) leftOf Interval.open(0, 4)) == false)
+    assert((Interval.open(2, 6) leftOf Interval.open(0, 4)) == false)
   }
 
   "rightOf" should "work" in {
-    assert((Interval.open(0, 4) rightOf Interval.open(4, 8))  == false)
-    assert((Interval.open(0, 4) rightOf Interval.open(2, 6))  == false)
-    assert((Interval.open(4, 8) rightOf Interval.open(0, 4))  == true)
-    assert((Interval.open(2, 6) rightOf Interval.open(0, 4))  == false)
+    assert((Interval.open(0, 4) rightOf Interval.open(4, 8)) == false)
+    assert((Interval.open(0, 4) rightOf Interval.open(2, 6)) == false)
+    assert((Interval.open(4, 8) rightOf Interval.open(0, 4)) == true)
+    assert((Interval.open(2, 6) rightOf Interval.open(0, 4)) == false)
   }
 
   "overlapping intervals" should "have distance 0" in {
-    assert((Interval.open(0, 4) distance Interval.open(2, 6))  ==  (0))
-    assert((Interval.open(2, 6) distance Interval.open(0, 3))  ==  (0))
+    assert((Interval.open(0, 4) distance Interval.open(2, 6)) == (0))
+    assert((Interval.open(2, 6) distance Interval.open(0, 3)) == (0))
   }
 
   they should "have the correct distance" in {
-    assert((Interval.open(0, 2) distance Interval.open(2, 5))  ==  (1))
-    assert((Interval.open(0, 2) distance Interval.open(3, 5))  ==  (2))
-    assert((Interval.open(0, 2) distance Interval.open(4, 6))  ==  (3))
+    assert((Interval.open(0, 2) distance Interval.open(2, 5)) == (1))
+    assert((Interval.open(0, 2) distance Interval.open(3, 5)) == (2))
+    assert((Interval.open(0, 2) distance Interval.open(4, 6)) == (3))
   }
 
   "adjacent intervals" should "have the empty set between them" in {
-    assert(Interval.between(Interval.open(0, 2), Interval.open(2, 3))  ==  (Interval.empty))
+    assert(Interval.between(Interval.open(0, 2), Interval.open(2, 3)) == (Interval.empty))
   }
 
   "between" should "work properly" in {
-    assert(Interval.between(Interval.open(0, 2), Interval.open(3, 10))  ==  (Interval.open(2, 3)))
-    assert(Interval.between(Interval.open(0, 2), Interval.open(6, 10))  ==  (Interval.open(2, 6)))
+    assert(Interval.between(Interval.open(0, 2), Interval.open(3, 10)) == (Interval.open(2, 3)))
+    assert(Interval.between(Interval.open(0, 2), Interval.open(6, 10)) == (Interval.open(2, 6)))
   }
 
   val intervalGen = for {
@@ -153,25 +153,25 @@ class IntervalSpec extends UnitSpec with Checkers {
   }
 
   "empty" should "work properly" in {
-    assert((Interval.empty union Interval.open(2, 4))  ==  (Interval.open(2, 4)))
-    assert((Interval.empty intersect Interval.open(2, 4))  ==  (Interval.empty))
+    assert((Interval.empty union Interval.open(2, 4)) == (Interval.open(2, 4)))
+    assert((Interval.empty intersect Interval.open(2, 4)) == (Interval.empty))
 
-    assert((Interval.empty left Interval.open(2, 4))  ==  (Interval.open(2, 4)))
-    assert((Interval.open(2, 4) left Interval.empty)  ==  (Interval.open(2, 4)))
-    assert((Interval.empty right Interval.open(2, 4))  ==  (Interval.open(2, 4)))
-    assert((Interval.open(2, 4) right Interval.empty)  ==  (Interval.open(2, 4)))
+    assert((Interval.empty left Interval.open(2, 4)) == (Interval.open(2, 4)))
+    assert((Interval.open(2, 4) left Interval.empty) == (Interval.open(2, 4)))
+    assert((Interval.empty right Interval.open(2, 4)) == (Interval.open(2, 4)))
+    assert((Interval.open(2, 4) right Interval.empty) == (Interval.open(2, 4)))
 
-    assert((Interval.open(2, 4) subset Interval.empty)  == false)
-    assert((Interval.empty subset Interval.open(2, 4))  == true)
+    assert((Interval.open(2, 4) subset Interval.empty) == false)
+    assert((Interval.empty subset Interval.open(2, 4)) == true)
 
-    assert((Interval.open(2, 4) superset Interval.empty)  == true)
-    assert((Interval.empty superset Interval.open(2, 4))  == false)
-    
-    intercept[IllegalArgumentException] {Interval.empty.min}
-    intercept[IllegalArgumentException] {Interval.empty.max}
-    intercept[IllegalArgumentException] {Interval.empty leftOf Interval.open(2, 4)}
-    intercept[IllegalArgumentException] {Interval.open(2, 4) rightOf Interval.empty}
-    
+    assert((Interval.open(2, 4) superset Interval.empty) == true)
+    assert((Interval.empty superset Interval.open(2, 4)) == false)
+
+    intercept[IllegalArgumentException] { Interval.empty.min }
+    intercept[IllegalArgumentException] { Interval.empty.max }
+    intercept[IllegalArgumentException] { Interval.empty leftOf Interval.open(2, 4) }
+    intercept[IllegalArgumentException] { Interval.open(2, 4) rightOf Interval.empty }
+
     assert(Interval.empty.shift(5) == Interval.empty)
   }
 
@@ -183,7 +183,7 @@ class IntervalSpec extends UnitSpec with Checkers {
   "empty" should "round trip through serialization" in {
     roundtripsOk(Interval.empty)
   }
-  
+
   "singleton intervals" should "round trip through serialization" in {
     check { (x: Int) =>
       (x < Int.MaxValue) ==> {
@@ -191,7 +191,7 @@ class IntervalSpec extends UnitSpec with Checkers {
         Interval.closed(x, x) == interval
       }
     }
-  
+
     check { (x: Int) =>
       (x < Int.MaxValue) ==> {
         val interval: Interval = Interval.singleton(x)
@@ -208,7 +208,7 @@ class IntervalSpec extends UnitSpec with Checkers {
       }
     }
   }
-  
+
   "closed intervals" should "round trip through serialization" in {
     check { (a: Int, b: Int) =>
       (a <= b && b < Int.MaxValue) ==> {


### PR DESCRIPTION
@schmmd Implemented as mentioned in [Wrike](https://www.wrike.com/open.htm?id=27200469). Not sure how to test for breakage in existing code or how to increment version number. Note that there are two commits, one with the actual code changes, and another to fix formatting warnings.
