### PR TITLE
Add Json support for Interval, get rid of special Closed class

### DIFF
--- a/core/src/main/scala/org/allenai/common/immutable/Interval.scala
+++ b/core/src/main/scala/org/allenai/common/immutable/Interval.scala
@@ -269,7 +269,7 @@ sealed class Interval private (val start: Int, val end: Int)
 
 object Interval {
   /** The empty interval. */
-  val empty = Empty
+  val empty: Interval = Empty
 
   /** Create a new singleton interval. */
   def singleton(x: Int): Singleton = new SingletonImpl(x)

--- a/core/src/test/scala/org/allenai/common/immutable/IntervalSpec.scala
+++ b/core/src/test/scala/org/allenai/common/immutable/IntervalSpec.scala
@@ -232,7 +232,7 @@ class IntervalSpec extends UnitSpec with Checkers {
     roundtripsJsonOk(Interval.open(3, 4))
     roundtripsJsonOk(Interval.open(2, 4))
     roundtripsJsonOk(Interval.closed(3, 6))
-    //assert(Interval.empty.toJson.toString == "[]")  /* Interval.empty has weird type */
+    assert(Interval.empty.toJson.toString == "[]")
     assert(Interval.open(3, 3).toJson.toString == "[]")
     assert(Interval.open(3, 4).toJson.toString == "[3,4]")
     assert(Interval.closed(3, 4).toJson.toString == "[3,5]")


### PR DESCRIPTION
@schmmd @gmjabs Michael suggested I include Greg on this. After the back and forth on HipChat, Michael suggested getting rid of the special Closed class (used for print form only), so I did that (but kept the Interval.closed constructor). For the Json format I then stuck with the original [start, end] array (and [] for the empty interval). We could instead do {"type": "open", "start": 3, "end": 5}  and {"type": "empty"}, but since "open" is not completely unambiguous (it means include the start point, but not the end point), that might not add any clarity at the moment. We could always embellish this in the future if need be.
