### PR TITLE
Updates slf4j dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.11.3"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.1.3"
-  val sl4j = "org.slf4j" % "slf4j-api" % "1.7.5"
+  val sl4j = "org.slf4j" % "slf4j-api" % "1.7.6"
   val sprayJson = "io.spray" %% "spray-json" % "1.2.6"
   val sprayRouting = "io.spray" % "spray-routing" % "1.3.1"
   val typesafeConfig = "com.typesafe" % "config" % "1.2.0"


### PR DESCRIPTION
nlpstack and/or the polyparser depends on 1.7.6, and common depends on 1.7.5. Rather than put in an override, I'm updating the version that common uses.

@markschaake, can you confirm or deny this is a good idea?
