### PR TITLE
Handle git remotes with SSH format in Ai2CodeInfo

### DIFF
--- a/pipeline/src/main/scala/org/allenai/pipeline/CodeInfo.scala
+++ b/pipeline/src/main/scala/org/allenai/pipeline/CodeInfo.scala
@@ -69,7 +69,7 @@ trait Ai2CodeInfo extends HasCodeInfo {
         // Commit sha
         val sha = config.getString("sha1")
         // The list of remote git repo's
-        val remotes = config.getStringList("remotes").asScala.map(new URI(_))
+        val remotes = config.getStringList("remotes").asScala.map(parseRemote)
         // The sbt-release plugin requires the git repo to be clean.
         // However, we don't know for sure whether the repo has been pushed to a remote repo
         // It may not have been pushed at the time of build, but might be pushed later


### PR DESCRIPTION
@jakemannix this is to build the correct code URLs in the experiment HTML page.  Once this is merged, I will release a new common-pipeline version and start using it in scholar
