### PR TITLE
utf-8 decoding

### DIFF
--- a/pipeline/src/main/scala/org/allenai/pipeline/Artifact.scala
+++ b/pipeline/src/main/scala/org/allenai/pipeline/Artifact.scala
@@ -1,9 +1,9 @@
 package org.allenai.pipeline
 
 import org.allenai.common.Resource
-
 import java.io.{ InputStream, OutputStream }
 import java.net.URI
+import java.nio.charset.StandardCharsets
 
 /** Represents data in a persistent store. */
 trait Artifact {
@@ -126,44 +126,5 @@ class ArtifactStreamWriter(out: OutputStream) {
     out.write('\n')
   }
 
-  // This was lifted from java.util.zip.ZipOutputStream
-  private def asUTF8(s: String): Array[Byte] = {
-    val c = s.toCharArray
-    val len = c.length
-    // Count the number of encoded bytes...
-    var count = 0
-    for (i <- 0 until len) {
-      val ch = c(i)
-      if (ch <= 0x7f) {
-        count += 1
-      } else if (ch <= 0x7ff) {
-        count += 2
-      } else {
-        count += 3
-      }
-    }
-    // Now return the encoded bytes...
-    val b = new Array[Byte](count)
-    var off = 0
-    for (i <- 0 until len) {
-      val ch = c(i)
-      if (ch <= 0x7f) {
-        b(off) = ch.toByte
-        off += 1
-      } else if (ch <= 0x7ff) {
-        b(off) = ((ch >> 6) | 0xc0).toByte
-        off += 1
-        b(off) = ((ch & 0x3f) | 0x80).toByte
-        off += 1
-      } else {
-        b(off) = ((ch >> 12) | 0xe0).toByte
-        off += 1
-        b(off) = (((ch >> 6) & 0x3f) | 0x80).toByte
-        off += 1
-        b(off) = ((ch & 0x3f) | 0x80).toByte
-        off += 1
-      }
-    }
-    b
-  }
+  private def asUTF8(s: String): Array[Byte] = s.getBytes(StandardCharsets.UTF_8)
 }

--- a/pipeline/src/test/scala/org/allenai/pipeline/TestArtifact.scala
+++ b/pipeline/src/test/scala/org/allenai/pipeline/TestArtifact.scala
@@ -32,6 +32,15 @@ class TestArtifact extends UnitSpec with ScratchDirectory {
     file.delete()
   }
 
+  it should "write valid utf-8" in {
+    val input = "The term \ud835\udc43(\ud835\udc43\ud835\udc5d) in the equation below"
+    val file = new File(scratchDir, "flatFile.txt")
+    val a = new FileArtifact(file)
+    a.write(_.write(input))
+    val output = Source.fromInputStream(a.read).mkString
+    input should equal(output)
+  }
+
   "ZipFileArtifact" should "read/write" in {
     val rand = new Random()
 


### PR DESCRIPTION
I found that the `asUTF8` method below was not correctly decoding some weird characters that appear in some S2 data. 

```
"The term \ud835\udc43(\ud835\udc43\ud835\udc5d) in the equation below"
```

(No idea why this text contains those weird unicode characters, but they are valid unicode. Despite `d835` being called "INVALID CHARACTER" it is valid unicode. http://www.charbase.com/d835-unicode-invalid-character)

I replaced the original `asUTF8` with a simpler call to `getBytes` and added a unit test that fails on the existing code. I don't completely understand the bug, but this seems to fix my problem.

Any thoughts @rodneykinney ?

cc'ing @jkinkead since we chatted about this...
