### PR TITLE
link fixup

### DIFF
--- a/pipeline/src/main/scala/org/allenai/pipeline/Workflow.scala
+++ b/pipeline/src/main/scala/org/allenai/pipeline/Workflow.scala
@@ -69,8 +69,10 @@ object Workflow {
   }
 
   private def link(uri: URI) = uri.getScheme match {
-    case "s3" => new java.net.URI("http", s"${uri.getHost}.s3.amazonaws.com", uri.getPath,
-      null).toString
+    case "s3" | "s3n" =>
+      new java.net.URI("http", s"${uri.getHost}.s3.amazonaws.com", uri.getPath, null).toString
+    case "file" =>
+      new java.net.URI(null, null, uri.getPath, null)
     case _ => uri.toString
   }
 


### PR DESCRIPTION
Fixup the workflow output such that s3n links are mapped into clickable http links. See here an example where this is broken: http://ai2-s2.s3.amazonaws.com/pipeline/output/publish/summary/commoncrawl-2015-02-18-22-57-47.html.