### PR TITLE
one instance per test

### DIFF
--- a/testkit/src/main/scala/org/allenai/common/testkit/AllenAiBaseSpec.scala
+++ b/testkit/src/main/scala/org/allenai/common/testkit/AllenAiBaseSpec.scala
@@ -2,4 +2,4 @@ package org.allenai.common.testkit
 
 import org.scalatest._
 
-trait AllenAiBaseSpec extends FlatSpecLike with Matchers
+trait AllenAiBaseSpec extends FlatSpecLike with Matchers with OneInstancePerTest


### PR DESCRIPTION
OneInstancePerTest creates one instance of the "suite" per test, which prevents any accidental interference between tests via shared mutable state of the suite (either in memory or on disk). IIRC, it's the default mode of operation of JUnit.

I've updated s2's SparkTest with OneInstancePerTest and measured comparatively. The timings are very close. I see no reason to move all our test infrastructure to use OneInstancePerTest and avoid lost productivity due to surprises in the test infrastructure.

$ sbt clean && sbt compile && sbt test
\<no OneInstancePerTest\>
[info] ScalaTest
[info] Run completed in 55 seconds, 182 milliseconds.
[info] Total number of tests run: 46
[info] Suites: completed 24, aborted 0
[info] Tests: succeeded 46, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 46, Failed 0, Errors 0, Passed 46
[success] Total time: 72 s, completed Mar 20, 2015 8:50:30 AM

$ sbt clean && sbt compile && sbt test
\<with OneInstancePerTest\>
[info] ScalaTest
[info] Run completed in 56 seconds, 545 milliseconds.
[info] Total number of tests run: 46
[info] Suites: completed 24, aborted 0
[info] Tests: succeeded 46, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 46, Failed 0, Errors 0, Passed 46
[success] Total time: 74 s, completed Mar 20, 2015 8:53:24 AM