### PR TITLE
Adds startup timestamp to the info route

### DIFF
--- a/webapp/src/main/scala/org/allenai/common/webapp/InfoRoute.scala
+++ b/webapp/src/main/scala/org/allenai/common/webapp/InfoRoute.scala
@@ -15,7 +15,7 @@ import spray.routing.Route
   * @param info the info to serve
   */
 class InfoRoute(val info: Map[String, String] = Map.empty) {
-  val infoWithTime = info.updated("startupTimestamp", (System.currentTimeMillis() / 1000L).toString)
+  val infoWithTime = info.updated("startupTimestamp", System.currentTimeMillis().toString)
 
   def withVersion(version: Version): InfoRoute = {
     new InfoRoute(

--- a/webapp/src/main/scala/org/allenai/common/webapp/InfoRoute.scala
+++ b/webapp/src/main/scala/org/allenai/common/webapp/InfoRoute.scala
@@ -15,6 +15,8 @@ import spray.routing.Route
   * @param info the info to serve
   */
 class InfoRoute(val info: Map[String, String] = Map.empty) {
+  val infoWithTime = info.updated("startupTimestamp", (System.currentTimeMillis() / 1000L).toString)
+
   def withVersion(version: Version): InfoRoute = {
     new InfoRoute(
       info ++
@@ -37,14 +39,14 @@ class InfoRoute(val info: Map[String, String] = Map.empty) {
       pathEndOrSingleSlash {
         respondWithMediaType(MediaTypes.`application/json`) {
           complete {
-            info.toJson.prettyPrint
+            infoWithTime.toJson.prettyPrint
           }
         }
       }
     } ~
     path("info" / Segment) { key =>
       complete {
-        info.get(key) match {
+        infoWithTime.get(key) match {
           case Some(key) => key
           case None => (StatusCodes.NotFound, "Could not find info: " + key)
         }

--- a/webapp/src/main/scala/org/allenai/common/webapp/InfoRoute.scala
+++ b/webapp/src/main/scala/org/allenai/common/webapp/InfoRoute.scala
@@ -15,8 +15,6 @@ import spray.routing.Route
   * @param info the info to serve
   */
 class InfoRoute(val info: Map[String, String] = Map.empty) {
-  val infoWithTime = info.updated("startupTimestamp", System.currentTimeMillis().toString)
-
   def withVersion(version: Version): InfoRoute = {
     new InfoRoute(
       info ++
@@ -33,20 +31,23 @@ class InfoRoute(val info: Map[String, String] = Map.empty) {
 
   def withName(name: String): InfoRoute = new InfoRoute(info + ("name" -> name))
 
+  def withStartupTime(startupTime: Long = System.currentTimeMillis()): InfoRoute =
+    new InfoRoute(info + ("startupTime" -> startupTime.toString))
+
   // format: OFF
   def route: Route = get {
     pathPrefix("info") {
       pathEndOrSingleSlash {
         respondWithMediaType(MediaTypes.`application/json`) {
           complete {
-            infoWithTime.toJson.prettyPrint
+            info.toJson.prettyPrint
           }
         }
       }
     } ~
     path("info" / Segment) { key =>
       complete {
-        infoWithTime.get(key) match {
+        info.get(key) match {
           case Some(key) => key
           case None => (StatusCodes.NotFound, "Could not find info: " + key)
         }


### PR DESCRIPTION
@jkinkead, can you take a look?

When this is deployed, I'll change the daily eval script to use this to detect when QI has restarted, and disregard any evaluation that was affected.