### PR TITLE
Add the correct moduleName for publishing to bintray.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 lazy val buildSettings = Seq(
   organization := "org.allenai.common",
+  moduleName := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
   crossScalaVersions := Seq("2.11.5"),
   scalaVersion <<= crossScalaVersions { (vs: Seq[String]) => vs.head },
   publishMavenStyle := true,


### PR DESCRIPTION
I *think* this is what we need to make the post-publication merge step unnecessary.