### PR TITLE
Logging configuration

### DIFF
--- a/core/src/main/scala/org/allenai/common/Logging.scala
+++ b/core/src/main/scala/org/allenai/common/Logging.scala
@@ -61,8 +61,8 @@ trait Logging {
       * logger.Config("org.apache.spark").setLevel(Level.WARN)
       *
       * logger.Config().addAppender(
-      *   logger.Config.patternLayoutEncoder("%-5level [%thread]: %message%n"),
-      *   logger.Config.consoleAppender
+      *   logger.Config.newPatternLayoutEncoder("%-5level [%thread]: %message%n"),
+      *   logger.Config.newConsoleAppender
       * )
       * </code>
       *
@@ -91,11 +91,11 @@ trait Logging {
         * <code>
         * logger.Config()
         *   .addAppender(
-        *     logger.Config.patternLayoutEncoder("%-5level [%thread]: %message%n"),
-        *     logger.Config.consoleAppender)
+        *     logger.Config.newPatternLayoutEncoder("%-5level [%thread]: %message%n"),
+        *     logger.Config.newConsoleAppender)
         *   .addAppender(
-        *     logger.Config.htmlLayoutEncoder("%relative%thread%level%logger%msg"),
-        *     logger.Config.fileAppender("./log.html"))
+        *     logger.Config.newHtmlLayoutEncoder("%relative%thread%level%logger%msg"),
+        *     logger.Config.newFileAppender("./log.html"))
         * </code>
         */
       def addAppender(
@@ -115,13 +115,13 @@ trait Logging {
 
     /** Factory methods for some simple config objects. */
     object Config {
-      def patternLayoutEncoder(pattern: String): Encoder[ILoggingEvent] = {
+      def newPatternLayoutEncoder(pattern: String): Encoder[ILoggingEvent] = {
         val encoder = new PatternLayoutEncoder()
         encoder.setPattern(pattern)
         encoder
       }
 
-      def htmlLayoutEncoder(pattern: String): Encoder[ILoggingEvent] = {
+      def newHtmlLayoutEncoder(pattern: String): Encoder[ILoggingEvent] = {
         new LayoutWrappingEncoder[ILoggingEvent] {
           private val htmlLayout = new HTMLLayout()
           htmlLayout.setPattern(pattern)
@@ -143,11 +143,11 @@ trait Logging {
         }
       }
 
-      def consoleAppender(): OutputStreamAppender[ILoggingEvent] = {
+      def newConsoleAppender(): OutputStreamAppender[ILoggingEvent] = {
         new ConsoleAppender[ILoggingEvent]()
       }
 
-      def fileAppender(fileName: String): OutputStreamAppender[ILoggingEvent] = {
+      def newFileAppender(fileName: String): OutputStreamAppender[ILoggingEvent] = {
         val appender = new FileAppender[ILoggingEvent]()
         appender.setAppend(false)
         appender.setFile(fileName)

--- a/core/src/main/scala/org/allenai/common/Logging.scala
+++ b/core/src/main/scala/org/allenai/common/Logging.scala
@@ -53,7 +53,7 @@ trait Logging {
         internalLogger.error(message, throwable)
       }
 
-    /** Simple logback configuration. The logback APIs are obscure, complex and verbose.
+    /** Simple logback configuration.
       * Hopefully this will be discoverable by just typing <code>logger.config().[TAB]</code>
       *
       * Examples:

--- a/core/src/main/scala/org/allenai/common/Logging.scala
+++ b/core/src/main/scala/org/allenai/common/Logging.scala
@@ -5,8 +5,6 @@ import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.classic.html.HTMLLayout
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core._
-
-//import ch.qos.logback.core._
 import ch.qos.logback.core.encoder.{Encoder, LayoutWrappingEncoder}
 import org.slf4j.LoggerFactory
 
@@ -58,9 +56,14 @@ trait Logging {
     /** Simple logback configuration. The logback APIs are obscure, complex and verbose.
       * Hopefully this will be discoverable by just typing <code>logger.config().[TAB]</code>
       *
-      * Example:
+      * Examples:
       * <code>
       * logger.config("org.apache.spark").setLevel(Level.WARN)
+      *
+      * logger.config().addAppender(
+      *   logger.factory.patternLayoutEncoder("%-5level [%thread]: %message%n"),
+      *   logger.factory.consoleAppender
+      * )
       * </code>
       *
       * @param loggerName the logger name, by default ROOT.

--- a/core/src/main/scala/org/allenai/common/Logging.scala
+++ b/core/src/main/scala/org/allenai/common/Logging.scala
@@ -1,8 +1,16 @@
 package org.allenai.common
 
+import ch.qos.logback.classic.{Level, Logger}
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder
+import ch.qos.logback.classic.html.HTMLLayout
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core._
+
+//import ch.qos.logback.core._
+import ch.qos.logback.core.encoder.{Encoder, LayoutWrappingEncoder}
 import org.slf4j.LoggerFactory
 
-/** This trait is meant to be mixed into a class to provide logging.
+/** This trait is meant to be mixed into a class to provide logging and logging configuration.
   *
   * The enclosed methods provide a Scala-style logging signature where the
   * message is a block instead of a string.  This way the message string is
@@ -46,5 +54,102 @@ trait Logging {
       if (internalLogger.isErrorEnabled) {
         internalLogger.error(message, throwable)
       }
+
+    /** Simple logback configuration. The logback APIs are obscure, complex and verbose.
+      * Hopefully this will be discoverable by just typing <code>logger.config().[TAB]</code>
+      *
+      * Example:
+      * <code>
+      * logger.config("org.apache.spark").setLevel(Level.WARN)
+      * </code>
+      *
+      * @param loggerName the logger name, by default ROOT.
+      */
+    def config(loggerName: String = org.slf4j.Logger.ROOT_LOGGER_NAME) = {
+      new Config(loggerName)
+    }
+
+    class Config(loggerName: String = org.slf4j.Logger.ROOT_LOGGER_NAME) {
+      private val logger: Logger = LoggerFactory.getLogger(loggerName).asInstanceOf[Logger]
+
+      /** Resets the logger. */
+      def reset() = {
+        logger.getLoggerContext.reset()
+      }
+
+      /** Simple log level setting. Example:
+        * <code>
+        * logger.config("org.apache.spark").setLevel(Level.WARN)
+        * </code>
+        */
+      def setLevel(level: Level) = {
+        logger.setLevel(level)
+      }
+
+      /** Simple log appender creation. Example:
+        * <code>
+        * logger.config().addAppender(
+        *   logger.factory.patternLayoutEncoder("%-5level [%thread]: %message%n"),
+        *   logger.factory.consoleAppender
+        * )
+        * logger.config().addAppender(
+        *   logger.factory.htmlLayoutEncoder("%relative%thread%level%logger%msg"),
+        *   logger.factory.fileAppender("./log.html")
+        * )
+        * </code>
+        */
+      def addAppender(
+          encoder: Encoder[ILoggingEvent],
+          appender: OutputStreamAppender[ILoggingEvent]
+          ) = {
+        val loggerContext = logger.getLoggerContext
+        encoder.setContext(loggerContext)
+        encoder.start()
+        appender.setContext(loggerContext)
+        appender.setEncoder(encoder)
+        appender.start()
+        logger.addAppender(appender)
+      }
+    }
+
+    /** Factory methods for some simple config objects. */
+    object factory {
+      def patternLayoutEncoder(pattern: String) = {
+        val encoder = new PatternLayoutEncoder()
+        encoder.setPattern(pattern)
+        encoder
+      }
+
+      def htmlLayoutEncoder(pattern: String) = {
+        new LayoutWrappingEncoder[ILoggingEvent] {
+          private val htmlLayout = new HTMLLayout()
+          htmlLayout.setPattern(pattern)
+          setLayout(layout)
+
+          override def setLayout(layout: Layout[ILoggingEvent]) = {
+            throw new Exception("Layout set via Logging.logger.config.htmlLayoutEncoder")
+          }
+
+          override def setContext(loggerContext: Context) = {
+            htmlLayout.setContext(loggerContext)
+            super.setContext(loggerContext)
+          }
+
+          override def start() = {
+            htmlLayout.start()
+            super.start()
+          }
+        }
+      }
+
+      def consoleAppender() = new ConsoleAppender[ILoggingEvent]()
+
+      def fileAppender(fileName: String) = {
+        val appender = new FileAppender[ILoggingEvent]()
+        appender.setAppend(false)
+        appender.setFile(fileName)
+        appender
+      }
+    }
   }
 }

--- a/core/src/main/scala/org/allenai/common/Logging.scala
+++ b/core/src/main/scala/org/allenai/common/Logging.scala
@@ -72,8 +72,9 @@ trait Logging {
       private val logger: Logger = LoggerFactory.getLogger(loggerName).asInstanceOf[Logger]
 
       /** Resets the logger. */
-      def reset() = {
+      def reset(): Config = {
         logger.getLoggerContext.reset()
+        this
       }
 
       /** Simple log level setting. Example:
@@ -81,26 +82,26 @@ trait Logging {
         * logger.Config("org.apache.spark").setLevel(Level.WARN)
         * </code>
         */
-      def setLevel(level: Level) = {
+      def setLevel(level: Level): Config = {
         logger.setLevel(level)
+        this
       }
 
       /** Simple log appender creation. Example:
         * <code>
-        * logger.Config().addAppender(
-        *   logger.Config.patternLayoutEncoder("%-5level [%thread]: %message%n"),
-        *   logger.Config.consoleAppender
-        * )
-        * logger.Config().addAppender(
-        *   logger.Config.htmlLayoutEncoder("%relative%thread%level%logger%msg"),
-        *   logger.Config.fileAppender("./log.html")
-        * )
+        * logger.Config()
+        *   .addAppender(
+        *     logger.Config.patternLayoutEncoder("%-5level [%thread]: %message%n"),
+        *     logger.Config.consoleAppender)
+        *   .addAppender(
+        *     logger.Config.htmlLayoutEncoder("%relative%thread%level%logger%msg"),
+        *     logger.Config.fileAppender("./log.html"))
         * </code>
         */
       def addAppender(
         encoder: Encoder[ILoggingEvent],
         appender: OutputStreamAppender[ILoggingEvent]
-      ) = {
+      ): Config = {
         val loggerContext = logger.getLoggerContext
         encoder.setContext(loggerContext)
         encoder.start()
@@ -108,18 +109,19 @@ trait Logging {
         appender.setEncoder(encoder)
         appender.start()
         logger.addAppender(appender)
+        this
       }
     }
 
     /** Factory methods for some simple config objects. */
     object Config {
-      def patternLayoutEncoder(pattern: String) = {
+      def patternLayoutEncoder(pattern: String): Encoder[ILoggingEvent] = {
         val encoder = new PatternLayoutEncoder()
         encoder.setPattern(pattern)
         encoder
       }
 
-      def htmlLayoutEncoder(pattern: String) = {
+      def htmlLayoutEncoder(pattern: String): Encoder[ILoggingEvent] = {
         new LayoutWrappingEncoder[ILoggingEvent] {
           private val htmlLayout = new HTMLLayout()
           htmlLayout.setPattern(pattern)
@@ -141,9 +143,11 @@ trait Logging {
         }
       }
 
-      def consoleAppender() = new ConsoleAppender[ILoggingEvent]()
+      def consoleAppender(): OutputStreamAppender[ILoggingEvent] = {
+        new ConsoleAppender[ILoggingEvent]()
+      }
 
-      def fileAppender(fileName: String) = {
+      def fileAppender(fileName: String): OutputStreamAppender[ILoggingEvent] = {
         val appender = new FileAppender[ILoggingEvent]()
         appender.setAppend(false)
         appender.setFile(fileName)

--- a/core/src/main/scala/org/allenai/common/Logging.scala
+++ b/core/src/main/scala/org/allenai/common/Logging.scala
@@ -54,25 +54,21 @@ trait Logging {
       }
 
     /** Simple logback configuration.
-      * Hopefully this will be discoverable by just typing <code>logger.config().[TAB]</code>
+      * Hopefully this will be discoverable by just typing <code>logger.Config().[TAB]</code>
       *
       * Examples:
       * <code>
-      * logger.config("org.apache.spark").setLevel(Level.WARN)
+      * logger.Config("org.apache.spark").setLevel(Level.WARN)
       *
-      * logger.config().addAppender(
-      *   logger.factory.patternLayoutEncoder("%-5level [%thread]: %message%n"),
-      *   logger.factory.consoleAppender
+      * logger.Config().addAppender(
+      *   logger.Config.patternLayoutEncoder("%-5level [%thread]: %message%n"),
+      *   logger.Config.consoleAppender
       * )
       * </code>
       *
       * @param loggerName the logger name, by default ROOT.
       */
-    def config(loggerName: String = org.slf4j.Logger.ROOT_LOGGER_NAME) = {
-      new Config(loggerName)
-    }
-
-    class Config(loggerName: String = org.slf4j.Logger.ROOT_LOGGER_NAME) {
+    case class Config(loggerName: String = org.slf4j.Logger.ROOT_LOGGER_NAME) {
       private val logger: Logger = LoggerFactory.getLogger(loggerName).asInstanceOf[Logger]
 
       /** Resets the logger. */
@@ -82,7 +78,7 @@ trait Logging {
 
       /** Simple log level setting. Example:
         * <code>
-        * logger.config("org.apache.spark").setLevel(Level.WARN)
+        * logger.Config("org.apache.spark").setLevel(Level.WARN)
         * </code>
         */
       def setLevel(level: Level) = {
@@ -91,13 +87,13 @@ trait Logging {
 
       /** Simple log appender creation. Example:
         * <code>
-        * logger.config().addAppender(
-        *   logger.factory.patternLayoutEncoder("%-5level [%thread]: %message%n"),
-        *   logger.factory.consoleAppender
+        * logger.Config().addAppender(
+        *   logger.Config.patternLayoutEncoder("%-5level [%thread]: %message%n"),
+        *   logger.Config.consoleAppender
         * )
-        * logger.config().addAppender(
-        *   logger.factory.htmlLayoutEncoder("%relative%thread%level%logger%msg"),
-        *   logger.factory.fileAppender("./log.html")
+        * logger.Config().addAppender(
+        *   logger.Config.htmlLayoutEncoder("%relative%thread%level%logger%msg"),
+        *   logger.Config.fileAppender("./log.html")
         * )
         * </code>
         */
@@ -116,7 +112,7 @@ trait Logging {
     }
 
     /** Factory methods for some simple config objects. */
-    object factory {
+    object Config {
       def patternLayoutEncoder(pattern: String) = {
         val encoder = new PatternLayoutEncoder()
         encoder.setPattern(pattern)

--- a/core/src/main/scala/org/allenai/common/Logging.scala
+++ b/core/src/main/scala/org/allenai/common/Logging.scala
@@ -1,11 +1,11 @@
 package org.allenai.common
 
-import ch.qos.logback.classic.{Level, Logger}
+import ch.qos.logback.classic.{ Level, Logger }
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.classic.html.HTMLLayout
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core._
-import ch.qos.logback.core.encoder.{Encoder, LayoutWrappingEncoder}
+import ch.qos.logback.core.encoder.{ Encoder, LayoutWrappingEncoder }
 import org.slf4j.LoggerFactory
 
 /** This trait is meant to be mixed into a class to provide logging and logging configuration.
@@ -102,9 +102,9 @@ trait Logging {
         * </code>
         */
       def addAppender(
-          encoder: Encoder[ILoggingEvent],
-          appender: OutputStreamAppender[ILoggingEvent]
-          ) = {
+        encoder: Encoder[ILoggingEvent],
+        appender: OutputStreamAppender[ILoggingEvent]
+      ) = {
         val loggerContext = logger.getLoggerContext
         encoder.setContext(loggerContext)
         encoder.start()

--- a/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
@@ -1,0 +1,34 @@
+package org.allenai.common
+
+import java.nio.file.Files
+
+import ch.qos.logback.classic.Level
+import org.allenai.common.testkit.UnitSpec
+
+import scala.io.Source
+
+class LoggingConfigSpec extends UnitSpec with Logging {
+  "logging.config" should "work" in {
+    val path = Files.createTempFile("nio-temp", ".tmp")
+    path.toFile().deleteOnExit()
+
+    val l = logger.config("org.allenai.common")
+    l.reset()
+    l.addAppender(
+      logger.factory.patternLayoutEncoder("%-5level [%thread]: %message%n"),
+      logger.factory.fileAppender(path.toString)
+    )
+    l.setLevel(Level.WARN)
+    logger.info("info should not be visible")
+    logger.warn("warn should be visible")
+    logger.warn("warn should be visible 2")
+
+    assert(
+      Source.fromFile(path.toString).mkString ===
+      """WARN  [ScalaTest-run-running-LoggingConfigSpec]: warn should be visible
+        |WARN  [ScalaTest-run-running-LoggingConfigSpec]: warn should be visible 2
+        |""".stripMargin)
+
+    println(Source.fromFile(path.toString).mkString)
+  }
+}

--- a/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
@@ -12,13 +12,13 @@ class LoggingConfigSpec extends UnitSpec with Logging {
     val path = Files.createTempFile("nio-temp", ".tmp")
     path.toFile().deleteOnExit()
 
-    val l = logger.Config("org.allenai.common")
-    l.reset()
-    l.addAppender(
-      logger.Config.patternLayoutEncoder("%-5level: %message%n"),
-      logger.Config.fileAppender(path.toString)
-    )
-    l.setLevel(Level.WARN)
+    logger.Config("org.allenai.common")
+      .reset()
+      .addAppender(
+        logger.Config.patternLayoutEncoder("%-5level: %message%n"),
+        logger.Config.fileAppender(path.toString)
+      )
+      .setLevel(Level.WARN)
 
     logger.info("info should not be visible")
     logger.warn("warn should be visible")

--- a/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
@@ -11,12 +11,12 @@ class LoggingConfigSpec extends UnitSpec with Logging {
   "logging.config" should "work" in {
     val path = Files.createTempFile("nio-temp", ".tmp")
     path.toFile().deleteOnExit()
-
-    logger.Config("org.allenai.common")
+    
+    loggerConfig.Logger("org.allenai.common")
       .reset()
       .addAppender(
-        logger.Config.newPatternLayoutEncoder("%-5level: %message%n"),
-        logger.Config.newFileAppender(path.toString)
+        loggerConfig.newPatternLayoutEncoder("%-5level: %message%n"),
+        loggerConfig.newFileAppender(path.toString)
       )
       .setLevel(Level.WARN)
 

--- a/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
@@ -25,9 +25,10 @@ class LoggingConfigSpec extends UnitSpec with Logging {
 
     assert(
       Source.fromFile(path.toString).mkString ===
-      """WARN  [ScalaTest-run-running-LoggingConfigSpec]: warn should be visible
+        """WARN  [ScalaTest-run-running-LoggingConfigSpec]: warn should be visible
         |WARN  [ScalaTest-run-running-LoggingConfigSpec]: warn should be visible 2
-        |""".stripMargin)
+        |""".stripMargin
+    )
 
     println(Source.fromFile(path.toString).mkString)
   }

--- a/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
@@ -15,21 +15,20 @@ class LoggingConfigSpec extends UnitSpec with Logging {
     val l = logger.config("org.allenai.common")
     l.reset()
     l.addAppender(
-      logger.factory.patternLayoutEncoder("%-5level [%thread]: %message%n"),
+      logger.factory.patternLayoutEncoder("%-5level: %message%n"),
       logger.factory.fileAppender(path.toString)
     )
     l.setLevel(Level.WARN)
+
     logger.info("info should not be visible")
     logger.warn("warn should be visible")
     logger.warn("warn should be visible 2")
-
+    
     assert(
       Source.fromFile(path.toString).mkString ===
-        """WARN  [ScalaTest-run-running-LoggingConfigSpec]: warn should be visible
-        |WARN  [ScalaTest-run-running-LoggingConfigSpec]: warn should be visible 2
-        |""".stripMargin
+        """WARN : warn should be visible
+          |WARN : warn should be visible 2
+          |""".stripMargin
     )
-
-    println(Source.fromFile(path.toString).mkString)
   }
 }

--- a/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
@@ -12,18 +12,18 @@ class LoggingConfigSpec extends UnitSpec with Logging {
     val path = Files.createTempFile("nio-temp", ".tmp")
     path.toFile().deleteOnExit()
 
-    val l = logger.config("org.allenai.common")
+    val l = logger.Config("org.allenai.common")
     l.reset()
     l.addAppender(
-      logger.factory.patternLayoutEncoder("%-5level: %message%n"),
-      logger.factory.fileAppender(path.toString)
+      logger.Config.patternLayoutEncoder("%-5level: %message%n"),
+      logger.Config.fileAppender(path.toString)
     )
     l.setLevel(Level.WARN)
 
     logger.info("info should not be visible")
     logger.warn("warn should be visible")
     logger.warn("warn should be visible 2")
-    
+
     assert(
       Source.fromFile(path.toString).mkString ===
         """WARN : warn should be visible

--- a/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
@@ -15,8 +15,8 @@ class LoggingConfigSpec extends UnitSpec with Logging {
     logger.Config("org.allenai.common")
       .reset()
       .addAppender(
-        logger.Config.patternLayoutEncoder("%-5level: %message%n"),
-        logger.Config.fileAppender(path.toString)
+        logger.Config.newPatternLayoutEncoder("%-5level: %message%n"),
+        logger.Config.newFileAppender(path.toString)
       )
       .setLevel(Level.WARN)
 


### PR DESCRIPTION
Thin wrapper to simplify logging configuration. Some defaults are already chosen, to point is to be easy to use, not to read 100 pages of docs to figure out which value goes into which slot. Open for future extension, once the additional needs become clearer.

In the big picture, the logback APIs are obscure, complex and verbose. logback.xml is uhm,  http://knowyourmeme.com/photos/552084-ha-ha-ha-no. Using programatic log configuration is unambiguous and can be easily customized for different scenarios.

APIs are not perfect, now it is the best moment to suggest improvements :)

Originating from https://github.com/allenai/euclid/blob/master/src/main/scala/org/allenai/euclid/Main.scala#L32