### PR TITLE
Override bintray name after applying bintray settings.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import bintray.Keys.{ bintray => bintrayKey }
 
 lazy val buildSettings = Seq(
   organization := "org.allenai.common",
-  (name in bintrayKey) := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
   crossScalaVersions := Seq("2.11.5"),
   scalaVersion <<= crossScalaVersions { (vs: Seq[String]) => vs.head },
   publishMavenStyle := true,
@@ -21,7 +20,10 @@ lazy val buildSettings = Seq(
         <email>dev-role@allenai.org</email>
       </developer>
     </developers>)
-) ++ bintray.Plugin.bintrayPublishSettings
+) ++ bintray.Plugin.bintrayPublishSettings :+ (
+  (name in bintrayKey) :=
+    s"${organization.value}:${name.value}_${scalaBinaryVersion.value}"
+)
 
 lazy val testkit = Project(
   id = "testkit",


### PR DESCRIPTION
This should make the bintray package name correct again.