### PR TITLE
Make Enum java serializable

### DIFF
--- a/core/src/main/scala/org/allenai/common/Enum.scala
+++ b/core/src/main/scala/org/allenai/common/Enum.scala
@@ -25,7 +25,7 @@ import spray.json.DefaultJsonProtocol._
   * }}}
   * (format: ON)
   */
-abstract class Enum[E <: Enum[E]](val id: String) {
+abstract class Enum[E <: Enum[E]](val id: String) extends Serializable {
   override def toString: String = id
 }
 


### PR DESCRIPTION
Our `Enum` was not serializable. This caused runtime exceptions during Spark pipeline runs due to failed java serialization during closure compilation.

@vha14 I'm pretty sure this will fix any java serialization issues we have with our Enum's. The unit test I added failed before having `Enum` extend `Serializable`

@dirkgr FYI