### PR TITLE
Relax self-type of ScratchDirectory

### DIFF
--- a/core/src/it/scala/org/allenai/common/cache/QueryCacheSpec.scala
+++ b/core/src/it/scala/org/allenai/common/cache/QueryCacheSpec.scala
@@ -4,7 +4,7 @@ import java.io.File
 import org.allenai.common.{ GitVersion, Version, cache }
 import org.allenai.common.testkit.UnitSpec
 import org.scalatest.BeforeAndAfterAll
-import spray.json.DefaultJsonProtocol._
+import spray.json.DefaultJsonProtocol
 import sys.process._
 
 case class Foo(stringVar: String, intVar: Int)
@@ -14,7 +14,7 @@ object FooJsonProtocol extends DefaultJsonProtocol {
 }
 
 class QueryCaches(redisHostname: String, redisPort: Int) {
-  import FooJsonProtocol.__
+  import FooJsonProtocol._
 
   val stringQueryCache = new JsonQueryCache[String](redisHostname, redisPort, "test")
   val intQueryCache = new JsonQueryCache[Int](redisHostname, redisPort, "test")

--- a/testkit/src/main/scala/org/allenai/common/testkit/ScratchDirectory.scala
+++ b/testkit/src/main/scala/org/allenai/common/testkit/ScratchDirectory.scala
@@ -7,7 +7,7 @@ import java.nio.file.Files
 
 /** Provides a scratch directory for writing unit-test output */
 trait ScratchDirectory extends BeforeAndAfterAll {
-  this: UnitSpec =>
+  this: AllenAiBaseSpec =>
 
   val scratchDir: File = {
     val dir = Files.createTempDirectory(this.getClass.getSimpleName).toFile
@@ -28,5 +28,4 @@ trait ScratchDirectory extends BeforeAndAfterAll {
     }
     f.delete()
   }
-
 }


### PR DESCRIPTION
@jkinkead mind taking this one?

Motivation: we have a `UnitSpec` that requires one-instance-per-test. I want to use the `ScratchDirectory` in a test that does not create a new instance per test. Relaxing the self type allows me to do that.

Also, fixed integration test compile error. Should probably add `sbt it:compile` to the Semaphore build to prevent this (I'll do this after merge).