### PR TITLE
Allow for segmenting by paragraph in BuildCorpusIndex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .cache
+.cache-main
+*.swp
 .classpath
 .project
 .settings

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .cache
-.cache-main
-*.swp
 .classpath
 .project
 .settings

--- a/indexing/README.md
+++ b/indexing/README.md
@@ -5,7 +5,7 @@
 
 Builds an elasticsearch index on an existing ElasticSearch instance, using one of the configurations defined in the indexing.conf file in resources/org/allenai/ari/indexing.
 
-To use this, you need to have a running instance of ElasticSearch (can be local or remote). As of this writing, the latest version is `1.7.2`. To install: Refer to http://joelabrahamsson.com/elasticsearch-101/ to get started, or use `brew install elasticsearch`
+To use this, you need to have a running instance of ElasticSearch (can be local or remote). As of this writing, the latest version is `1.7.2`. To install: Refer to http://joelabrahamsson.com/elasticsearch-101/ to get started, or use `brew install elasticsearch`.  NOTE: you need to have the _same_ version of elastic search installed as the code is using, or you will get obtuse errors.  `brew install elasticsearch` installed version 2.1.0 as of 12/2015, and the code is currently using version 1.7.1.  You need to use the command `brew install homebrew/versions/elasticsearch17` to install the correct version of elasticsearch.
 Once you have ElasticSearch, go to the `bin` directory and run: `./elasticsearch`
 
 Configurations are of the form:

--- a/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
@@ -123,24 +123,25 @@ org.allenai.common.indexing.simplewikipedia: ${org.allenai.common.indexing.sente
   ]
 }
 
-org.allenai.common.indexing.wikipedia: ${org.allenai.common.indexing.sentence_base} {
-  elasticSearch.indexName: "wikipedia"
+org.allenai.common.indexing.simplewikipedia_paragraph: ${org.allenai.common.indexing.paragraph_base} {
+  elasticSearch.indexName: "simplewikipedia-paragraph"
   corpora: [
     {
+      documentFormat: "simple wikipedia"
       group: "org.allenai.corpora.wikipedia"
-      directory: "Wikipedia-all"
+      file: "SimpleWikipedia-all.txt"
       version: 1
       privacy: "public"
     }
   ]
 }
 
-org.allenai.common.indexing.wikipedia_paragraph_test: ${org.allenai.common.indexing.paragraph_base} {
-  elasticSearch.indexName: "wikipedia-paragraph-test"
+org.allenai.common.indexing.wikipedia: ${org.allenai.common.indexing.sentence_base} {
+  elasticSearch.indexName: "wikipedia"
   corpora: [
     {
       group: "org.allenai.corpora.wikipedia"
-      file: "simple_wikipedia_first_few_articles.txt"
+      directory: "Wikipedia-all"
       version: 1
       privacy: "public"
     }

--- a/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
@@ -61,7 +61,6 @@ org.allenai.common.indexing.paragraph_base: ${org.allenai.common.indexing.base} 
           text: {
             type: "multi_field",
             fields: {
-              // Not sure yet what this "analyzer" field means.
               text: {type: "string", analyzer: "snowball"}
               text_raw: {type: "string", index: "not_analyzed"},
             }

--- a/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
@@ -182,3 +182,17 @@ org.allenai.common.indexing.ck12biov44: ${org.allenai.common.indexing.sentence_b
     }
   ]
 }
+
+org.allenai.common.indexing.barrons_paragraph: ${org.allenai.common.indexing.paragraph_base} {
+  elasticSearch.indexName: "barrons-paragraph"
+  corpora: [
+    {
+      documentFormat: "barrons"
+      group: "org.allenai.aristo.corpora.source"
+      directory:  "Barrons-4th-Grade"
+      version: 1
+      file: "Barrons.txt"
+    }
+  ]
+}
+

--- a/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
@@ -80,7 +80,8 @@ org.allenai.common.indexing.waterloo: ${org.allenai.common.indexing.sentence_bas
   elasticSearch.indexName: "waterloo"
   corpora: [
     {
-      corpusType: "waterloo"
+      pathIsLocal: true
+      documentFormat: "waterloo"
       directory: "/mnt/wumpus/Waterloo/CorpusSegmented"
     }
   ]

--- a/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
@@ -19,6 +19,16 @@ org.allenai.common.indexing.base: {
     hostIp: "127.0.0.1"
     hostPort: 9300
     indexName: "lucene"
+  }
+
+  buildIndexOptions: {
+    buildFromScratch: true
+    dumpFolder: "common/src/main/resources/org/allenai/ari/indexing/dump"
+  }
+}
+
+org.allenai.common.indexing.sentence_base: ${org.allenai.common.indexing.base} {
+  elasticSearch: {
     indexType: "sentence"
     mapping: {
       sentence: {
@@ -39,16 +49,35 @@ org.allenai.common.indexing.base: {
       }
     }
   }
+}
 
-  buildIndexOptions: {
-    buildFromScratch: true
-    dumpFolder: "common/src/main/resources/org/allenai/ari/indexing/dump"
+org.allenai.common.indexing.paragraph_base: ${org.allenai.common.indexing.base} {
+  elasticSearch: {
+    indexType: "paragraph"
+    mapping: {
+      paragraph: {
+        dynamic: false,
+        properties: {
+          text: {
+            type: "multi_field",
+            fields: {
+              // Not sure yet what this "analyzer" field means.
+              text: {type: "string", analyzer: "snowball"}
+              text_raw: {type: "string", index: "not_analyzed"},
+            }
+          }
+          source: {
+            type: "string",
+            index: "not_analyzed"
+          }
+        }
+      }
+    }
   }
 }
 
 
-
-org.allenai.common.indexing.waterloo: ${org.allenai.common.indexing.base} {
+org.allenai.common.indexing.waterloo: ${org.allenai.common.indexing.sentence_base} {
   elasticSearch.indexName: "waterloo"
   corpora: [
     {
@@ -58,7 +87,7 @@ org.allenai.common.indexing.waterloo: ${org.allenai.common.indexing.base} {
   ]
 }
 
-org.allenai.common.indexing.waterloofiltered1: ${org.allenai.common.indexing.base} {
+org.allenai.common.indexing.waterloofiltered1: ${org.allenai.common.indexing.sentence_base} {
   elasticSearch.indexName: "waterloofiltered1"
   corpora: [
     {
@@ -70,7 +99,7 @@ org.allenai.common.indexing.waterloofiltered1: ${org.allenai.common.indexing.bas
   ]
 }
 
-org.allenai.common.indexing.waterloofiltered2: ${org.allenai.common.indexing.base} {
+org.allenai.common.indexing.waterloofiltered2: ${org.allenai.common.indexing.sentence_base} {
   elasticSearch.indexName: "waterloofiltered2"
   corpora: [
     {
@@ -82,7 +111,7 @@ org.allenai.common.indexing.waterloofiltered2: ${org.allenai.common.indexing.bas
   ]
 }
 
-org.allenai.common.indexing.simplewikipedia: ${org.allenai.common.indexing.base} {
+org.allenai.common.indexing.simplewikipedia: ${org.allenai.common.indexing.sentence_base} {
   elasticSearch.indexName: "simplewikipedia"
   corpora: [
     {
@@ -94,7 +123,7 @@ org.allenai.common.indexing.simplewikipedia: ${org.allenai.common.indexing.base}
   ]
 }
 
-org.allenai.common.indexing.wikipedia: ${org.allenai.common.indexing.base} {
+org.allenai.common.indexing.wikipedia: ${org.allenai.common.indexing.sentence_base} {
   elasticSearch.indexName: "wikipedia"
   corpora: [
     {
@@ -106,7 +135,19 @@ org.allenai.common.indexing.wikipedia: ${org.allenai.common.indexing.base} {
   ]
 }
 
-org.allenai.common.indexing.barrons: ${org.allenai.common.indexing.base} {
+org.allenai.common.indexing.wikipedia_paragraph_test: ${org.allenai.common.indexing.paragraph_base} {
+  elasticSearch.indexName: "wikipedia-paragraph-test"
+  corpora: [
+    {
+      group: "org.allenai.corpora.wikipedia"
+      file: "simple_wikipedia_first_few_articles.txt"
+      version: 1
+      privacy: "public"
+    }
+  ]
+}
+
+org.allenai.common.indexing.barrons: ${org.allenai.common.indexing.sentence_base} {
   elasticSearch.indexName: "barrons"
   corpora: [
     {
@@ -118,7 +159,7 @@ org.allenai.common.indexing.barrons: ${org.allenai.common.indexing.base} {
   ]
 }
 
-org.allenai.common.indexing.websentences: ${org.allenai.common.indexing.base} {
+org.allenai.common.indexing.websentences: ${org.allenai.common.indexing.sentence_base} {
   elasticSearch.indexName: "websentences"
   corpora: [
     {
@@ -130,7 +171,7 @@ org.allenai.common.indexing.websentences: ${org.allenai.common.indexing.base} {
   ]
 }
 
-org.allenai.common.indexing.ck12biov44: ${org.allenai.common.indexing.base} {
+org.allenai.common.indexing.ck12biov44: ${org.allenai.common.indexing.sentence_base} {
   elasticSearch.indexName: "ck12biov44"
   corpora: [
     {

--- a/indexing/src/main/scala/org/allenai/common/indexing/BarronsDocumentReader.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/BarronsDocumentReader.scala
@@ -1,0 +1,42 @@
+package org.allenai.common.indexing
+
+import java.io.File
+import scala.io.Codec
+import scala.io.Source
+
+class BarronsDocumentReader(file: File, codec: Codec) {
+  def read(): SegmentedDocument = {
+    // Barron's isn't all that large, and this makes testing this a lot easier.
+    val lines = Source.fromFile(file)(codec).getLines.toSeq
+    _readLines(lines)
+  }
+
+  def _readLines(lines: Seq[String]): SegmentedDocument = {
+    // At this point, I'm just going to worry about getting paragraph structure out.  Sections and
+    // chapters will have to wait for another time, if someone cares about doing that some day.
+    // So, this is a really simple parsing algorithm that will just group consecutive sentences
+    // into paragraphs, where "consecutive" is defined by the sentence numbers in the original
+    // file.
+    var prevKey = ""
+    var prevSentence = ""
+    val builder = new SegmentedDocumentBuilder(lines.mkString("\n"))
+    for (line <- lines) {
+      val fields = line.split("\t")
+      val longNumber = fields(0)
+      val sentenceText = fields(1)
+      val (key, sentenceNumber) = longNumber.splitAt(longNumber.lastIndexOf("."))
+      if (key != prevKey) {
+        if (prevKey != "") {
+          builder.finishNonTerminalSegment()
+        }
+        prevKey = key
+        builder.startNewNonTerminalSegment("paragraph")
+      }
+      // I could check that the sentence number increments by one here, but I don't think that's
+      // actually necessary.  Just checking the key should be enough.
+      builder.addTerminalSegment("sentence", sentenceText)
+    }
+    builder.finishNonTerminalSegment()
+    builder.build()
+  }
+}

--- a/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
@@ -276,10 +276,9 @@ object BuildCorpusIndex {
     }
   }
 
-  /**
-   * Take the config for a corpus, resolve paths, and return a simple object containing information
-   * about the corpus.
-   */
+  /** Take the config for a corpus, resolve paths, and return a simple object containing information
+    * about the corpus.
+    */
   def parseCorpusConfig(corpusConfig: Config): ParsedConfig = {
     val documentFormat = corpusConfig.get[String]("documentFormat").getOrElse("plain text")
     val encoding = corpusConfig.get[String]("encoding").getOrElse("UTF-8")

--- a/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
@@ -131,7 +131,11 @@ class BuildCorpusIndex(config: Config) extends Logging {
     * @param fileTree file stream to be indexed
     * @return a sequence of Futures each representing the work done by a thread on this file tree.
     */
-  def addTreeToIndex(fileTree: Iterator[Path], codec: Codec, documentFormat: String): Seq[Future[Unit]] = {
+  def addTreeToIndex(
+    fileTree: Iterator[Path],
+    codec: Codec,
+    documentFormat: String
+  ): Seq[Future[Unit]] = {
     for (i <- 0 until nThreads * 4) yield {
       Future {
         val esClient =

--- a/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
@@ -22,7 +22,7 @@ import scala.io.{ Source, Codec }
 import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success }
 import java.io.File
-import java.nio.file.{ Files, Path }
+import java.nio.file.{ Files, Path, Paths }
 import java.util.concurrent.TimeUnit
 
 /** CLI to build an Elastic Search index on Aristo corpora.
@@ -51,146 +51,6 @@ class BuildCorpusIndex(config: Config) extends Logging {
 
   /** Regex used to split sentences in waterloo corpus. */
   val sentenceSplitRegex = """</?SENT>""".r.unanchored
-
-  /**
-   * Segment a line from a document into paragraphs.  For the files in the datastore format, this
-   * is trivially done by returning the line, as they are already segmented into paragraphs.
-   * @param line the line of text
-   */
-  def segmentByParagraph(line: String): Seq[String] = {
-    if (line.trim().isEmpty()) {
-      Seq.empty[String]
-    } else {
-      Seq[String](line)
-    }
-  }
-
-  /** Index a single segment into elasticsearch.
-    * @param segment to be indexed
-    * @param source name of source for reference
-    * @param segmentIndex index of segment in file (for deduplication)
-    * @param bulkProcessor to communicate with the elasticsearch instance
-    */
-  def addSegmentToIndex(
-    segment: String,
-    source: String,
-    segmentIndex: Int,
-    bulkProcessor: BulkProcessor
-  ): Unit = {
-    val request = new IndexRequest(indexName, indexType).source(jsonBuilder().startObject()
-      .field("text", segment.trim)
-      .field("source", source + "_" + segmentIndex.toString)
-      .endObject())
-    bulkProcessor.add(request)
-  }
-
-  /** Index a single file into elasticsearch.
-    * @param file to be indexed
-    * @param bulkProcessor to communicate with the elasticsearch instance
-    */
-  def addFileToIndex(
-    file: File,
-    bulkProcessor: BulkProcessor,
-    codec: Codec
-  ): Unit = {
-    val segmentFunction = indexType match {
-      case "sentence" => defaultSegmenter.segmentTexts _
-      case "paragraph" => segmentByParagraph _
-      case _ => throw new IllegalStateException("unrecognized index type")
-    }
-    val bufSource = Source.fromFile(file, 8192)(codec)
-    val lines = bufSource.getLines
-    (lines flatMap { segmentFunction }).zipWithIndex.foreach {
-      case (segment, segmentIndex) => {
-        addSegmentToIndex(segment, file.getName, segmentIndex, bulkProcessor)
-      }
-    }
-    var segmentIndex = 0
-    for (line <- lines; segment <- defaultSegmenter.segmentTexts(line)) {
-      addSegmentToIndex(segment, file.getName, segmentIndex, bulkProcessor)
-      segmentIndex += 1
-    }
-    bufSource.close()
-  }
-
-  /** Index a file tree into the elasticSearch instance.  Divides work into nThreads*4 Futures. Each
-    * future syncs on currentFile which is a logging variable, and then grabs the next file from the
-    * stream if it is not empty.
-    * @param fileTree file stream to be indexed
-    * @return a sequence of Futures each representing the work done by a thread on this file tree.
-    */
-  def addTreeToIndex(fileTree: Iterator[Path], codec: Codec): Seq[Future[Unit]] = {
-    for (i <- 0 until nThreads * 4) yield {
-      Future {
-        val esClient =
-          ElasticSearchTransportClientUtil.ConstructTransportClientFromESconfig(esConfig)
-        val bulkProcessor: BulkProcessor =
-          bulkProcessorUtility.buildDumpOnErrorBulkProcessor(esClient, dumpFolderPath)
-
-        // Implicit conversion here to ParIteratorEnrichment
-        fileTree parForeach (path => {
-          val file = path.toFile
-          // ignore .DS_STORE and any other hidden surprises that should not be indexed
-          if (!file.isDirectory && !file.isHidden) addFileToIndex(file, bulkProcessor, codec)
-        })
-
-        bulkProcessor.flush()
-        bulkProcessor.awaitClose(Integer.MAX_VALUE, TimeUnit.DAYS)
-        esClient.close()
-      }
-    }
-  }
-
-  /** Index a folder into the elasticsearch instance, following the convention of the waterloo
-    * corpus. Sentences are encapsulated by <SENT> ... </SENT> tags.
-    * @param indirPath path to the input directory
-    */
-  def addWaterlooDirectoryToIndex(indirPath: String, codec: Codec): Seq[Future[Unit]] = {
-    val indir = new File(indirPath)
-    for (file <- indir.listFiles; if !file.getName.startsWith(".")) yield {
-      Future {
-        file.setReadOnly()
-        logger.debug("Now indexing: " + file.getName)
-        val esClient = ElasticSearchTransportClientUtil.
-          ConstructTransportClientFromESconfig(esConfig, sniffMode = true)
-        val bulkProcessor: BulkProcessor = bulkProcessorUtility.
-          buildDumpOnErrorBulkProcessor(esClient, dumpFolderPath)
-        addWaterlooFileToIndex(file, bulkProcessor, codec)
-        logger.debug("Done indexing: " + file.getName)
-        bulkProcessor.flush()
-        bulkProcessor.awaitClose(Integer.MAX_VALUE, TimeUnit.DAYS)
-        esClient.close()
-      }
-    }
-  }
-
-  /** Index a file into the elasticsearch instance, following the convention of the waterloo corpus.
-    * Sentences are encapsulated by <SENT> ... </SENT> tags.
-    * @param inputFile path to the input directory
-    * @param bulkProcessor to communicate with the elasticsearch instace
-    */
-  def addWaterlooFileToIndex(inputFile: File, bulkProcessor: BulkProcessor, codec: Codec): Unit = {
-    indexType match {
-      case "sentence" => {}
-      case "paragraph" => throw new IllegalStateException("paragraph segmenting not implemented "
-        + "for waterloo corpora")
-      case _ => throw new IllegalStateException("unrecognized index type")
-    }
-    var filePositionCounter = 0
-
-    def segmentFunction(segment: String): Unit = {
-      addSegmentToIndex(segment, inputFile.getName, filePositionCounter, bulkProcessor)
-      filePositionCounter += 1
-    }
-    ParsingUtils.splitOnTag(
-      inputFile = inputFile,
-      splitString = "DOC",
-      splitRegex = sentenceSplitRegex,
-      segmentFunction = segmentFunction,
-      bufferSize = 16384,
-      codec
-    )
-  }
 
   /** Build an index in ElasticSearch using the corpora specified in config. */
   def buildElasticSearchIndex(): Unit = {
@@ -226,41 +86,16 @@ class BuildCorpusIndex(config: Config) extends Logging {
     }
 
     val corpusConfigs = config.get[Seq[Config]]("corpora").getOrElse(Seq.empty[Config])
+    val parsedConfigs = corpusConfigs.map(BuildCorpusIndex.parseCorpusConfig)
 
-    // Compile list of documents to be indexed in various formats
-    val waterlooPathList: Seq[(String, String)] =
-      BuildCorpusIndex.getWaterlooPathList(corpusConfigs)
-    val dataStoreFileTreeList: Seq[(Path, String)] =
-      BuildCorpusIndex.getDataStoreFileTreeList(corpusConfigs)
-    val dataStorePathList: Seq[(Path, String)] =
-      BuildCorpusIndex.getDataStoreFilePathList(corpusConfigs)
-
-    // Index all files
-    val datastorePathResults: Seq[Future[Unit]] = dataStorePathList.map {
-      case (path, encoding) =>
-        Future[Unit] {
-          logger.debug(s"Currently indexing: ${path.getFileName}")
-          val esClient =
-            ElasticSearchTransportClientUtil.ConstructTransportClientFromESconfig(esConfig)
-          val bulkProcessor: BulkProcessor =
-            bulkProcessorUtility.buildDumpOnErrorBulkProcessor(esClient, dumpFolderPath)
-          addFileToIndex(path.toFile, bulkProcessor, encoding)
-          bulkProcessor.flush()
-          bulkProcessor.awaitClose(Integer.MAX_VALUE, TimeUnit.DAYS)
-          esClient.close()
-        }
-    }
-    val datastoreTreeResults: Seq[Future[Unit]] = dataStoreFileTreeList flatMap {
-      case (path, encoding) => addTreeToIndex(Files.walk(path).iterator().asScala, encoding)
-    }
-    val waterlooPathResults: Seq[Future[Unit]] = waterlooPathList flatMap {
-      case (path, encoding) => addWaterlooDirectoryToIndex(path, encoding)
-    }
-
-    // combine all results into a single Future
-    val results: Future[Seq[Unit]] = Future.sequence(
-      datastoreTreeResults ++ datastorePathResults ++ waterlooPathResults
-    )
+    val results: Future[Seq[Unit]] = Future.sequence(parsedConfigs.flatMap(corpus => {
+      if (corpus.isDirectory) {
+        val iterator = Files.walk(corpus.path).iterator().asScala
+        addTreeToIndex(iterator, corpus.encoding, corpus.documentFormat)
+      } else {
+        addTreeToIndex(Seq(corpus.path).iterator, corpus.encoding, corpus.documentFormat)
+      }
+    }))
 
     results onComplete {
       case Success(l) =>
@@ -289,7 +124,120 @@ class BuildCorpusIndex(config: Config) extends Logging {
       logger.debug("No failed requests")
     }
   }
+
+  /** Index a file tree into the elasticSearch instance.  Divides work into nThreads*4 Futures. Each
+    * future syncs on currentFile which is a logging variable, and then grabs the next file from the
+    * stream if it is not empty.
+    * @param fileTree file stream to be indexed
+    * @return a sequence of Futures each representing the work done by a thread on this file tree.
+    */
+  def addTreeToIndex(fileTree: Iterator[Path], codec: Codec, documentFormat: String): Seq[Future[Unit]] = {
+    for (i <- 0 until nThreads * 4) yield {
+      Future {
+        val esClient =
+          ElasticSearchTransportClientUtil.ConstructTransportClientFromESconfig(esConfig)
+        val bulkProcessor: BulkProcessor =
+          bulkProcessorUtility.buildDumpOnErrorBulkProcessor(esClient, dumpFolderPath)
+
+        // Implicit conversion here to ParIteratorEnrichment
+        fileTree parForeach (path => {
+          val file = path.toFile
+          // ignore .DS_STORE and any other hidden surprises that should not be indexed
+          if (!file.isDirectory && !file.isHidden) {
+            addFileToIndex(file, bulkProcessor, codec, documentFormat)
+          }
+        })
+
+        bulkProcessor.flush()
+        bulkProcessor.awaitClose(Integer.MAX_VALUE, TimeUnit.DAYS)
+        esClient.close()
+      }
+    }
+  }
+
+  /** Index a single file into elasticsearch.
+    * @param file to be indexed
+    * @param bulkProcessor to communicate with the elasticsearch instance
+    */
+  def addFileToIndex(
+    file: File,
+    bulkProcessor: BulkProcessor,
+    codec: Codec,
+    documentFormat: String
+  ): Unit = {
+    if (documentFormat == "waterloo") {
+      addWaterlooFileToIndex(file, bulkProcessor, codec)
+    } else {
+      val segments = segmentFile(file, codec, documentFormat)
+      segments.zipWithIndex.foreach {
+        case (segment, segmentIndex) => {
+          addSegmentToIndex(segment, file.getName, segmentIndex, bulkProcessor)
+        }
+      }
+    }
+  }
+
+  /** Index a file into the elasticsearch instance, following the convention of the waterloo corpus.
+    * Sentences are encapsulated by <SENT> ... </SENT> tags.
+    * @param inputFile path to the input directory
+    * @param bulkProcessor to communicate with the elasticsearch instace
+    */
+  def addWaterlooFileToIndex(inputFile: File, bulkProcessor: BulkProcessor, codec: Codec): Unit = {
+    var filePositionCounter = 0
+
+    def segmentFunction(segment: String): Unit = {
+      addSegmentToIndex(segment, inputFile.getName, filePositionCounter, bulkProcessor)
+      filePositionCounter += 1
+    }
+    ParsingUtils.splitOnTag(
+      inputFile = inputFile,
+      splitString = "DOC",
+      splitRegex = sentenceSplitRegex,
+      segmentFunction = segmentFunction,
+      bufferSize = 16384,
+      codec
+    )
+  }
+
+  def segmentFile(file: File, codec: Codec, documentFormat: String): Iterator[String] = {
+    documentFormat match {
+      case "plain text" => segmentPlainTextFile(file, codec)
+      case "waterloo" => throw new IllegalStateException("you shouldn't have gotten here")
+      case _ => throw new IllegalStateException("Unrecognized document format")
+    }
+  }
+
+  def segmentPlainTextFile(file: File, codec: Codec): Iterator[String] = {
+    if (indexType != "sentence") {
+      throw new IllegalStateException("plain text can only be segmented into sentences")
+    }
+    val bufSource = Source.fromFile(file, 8192)(codec)
+    val lines = bufSource.getLines
+    (lines flatMap { defaultSegmenter.segmentTexts })
+  }
+
+  /** Index a single segment into elasticsearch.
+    * @param segment to be indexed
+    * @param source name of source for reference
+    * @param segmentIndex index of segment in file (for deduplication)
+    * @param bulkProcessor to communicate with the elasticsearch instance
+    */
+  def addSegmentToIndex(
+    segment: String,
+    source: String,
+    segmentIndex: Int,
+    bulkProcessor: BulkProcessor
+  ): Unit = {
+    val request = new IndexRequest(indexName, indexType).source(jsonBuilder().startObject()
+      .field("text", segment.trim)
+      .field("source", source + "_" + segmentIndex.toString)
+      .endObject())
+    bulkProcessor.add(request)
+  }
+
 }
+
+case class ParsedConfig(path: Path, isDirectory: Boolean, encoding: String, documentFormat: String)
 
 object BuildCorpusIndex {
 
@@ -309,72 +257,55 @@ object BuildCorpusIndex {
     }
   }
 
-  /** Compile list if file paths (for files in Waterloo Corpus format).
-    * @param corpusConfigs list of all corpus configs
-    * @return filtered list of waterloo format paths, paired with their encodings
-    */
-  def getWaterlooPathList(corpusConfigs: Seq[Config]): Seq[(String, String)] = {
-    corpusConfigs.filter(corpusConfig => {
-      val corpusType = corpusConfig.get[String]("corpusType")
-      corpusType.isDefined && corpusType.get.equals("waterloo")
-    }).map(corpusConfig => (corpusConfig[String]("directory"), corpusConfig.get[String]("encoding").
-      getOrElse("UTF-8")))
+  /**
+   * Take the config for a corpus, resolve paths, and return a simple object containing information
+   * about the corpus.
+   */
+  def parseCorpusConfig(corpusConfig: Config): ParsedConfig = {
+    val documentFormat = corpusConfig.get[String]("documentFormat").getOrElse("plain text")
+    val encoding = corpusConfig.get[String]("encoding").getOrElse("UTF-8")
+    // We could be a little smarter at detecting whether the intent was a local path, but this will
+    // do for now.
+    val pathIsLocal = corpusConfig.get[Boolean]("pathIsLocal").getOrElse(false)
+    val (path, isDirectory) = pathIsLocal match {
+      case true => getLocalPathFromConfig(corpusConfig)
+      case false => getDatastorePathFromConfig(corpusConfig)
+    }
+    ParsedConfig(path, isDirectory, encoding, documentFormat)
   }
 
-  /** Compile list of file trees from datastore.
-    * @param corpusConfigs list of all corpus configs
-    * @return filtered list of datastore directory file trees, paired with their encodings
-    */
-  def getDataStoreFileTreeList(corpusConfigs: Seq[Config]): Seq[(Path, String)] = {
-    val datastoreCorporaConfigs = corpusConfigs.filter(corpusConfig => {
-      val corpusType = corpusConfig.get[String]("corpusType")
-      corpusType.isEmpty || corpusType.get.equals("datastore")
-    })
-
-    datastoreCorporaConfigs.filter(config => config.hasPath("directory") && !config.hasPath("file"))
-      .map(config =>
-        (
-          Datastore(config.get[String]("privacy").getOrElse("private"))
-          .directoryPath(
-            config[String]("group"),
-            config[String]("directory"),
-            config[Int]("version")
-          ),
-            config.get[String]("encoding").getOrElse("UTF-8")
-        ))
-  }
-
-  /** Compile list of file paths from datastore.
-    * @param corpusConfigs list of all corpus configs
-    * @return filtered list of datastore paths, paired with their encodings
-    */
-  def getDataStoreFilePathList(corpusConfigs: Seq[Config]): Seq[(Path, String)] = {
-    val datastoreCorporaConfigs = corpusConfigs.filter(corpusConfig => {
-      val corpusType = corpusConfig.get[String]("corpusType")
-      corpusType.isEmpty || corpusType.get.equals("datastore")
-    })
-
-    datastoreCorporaConfigs.filter(config => config.hasPath("file")).map { config =>
-      val privacy = config.get[String]("privacy").getOrElse("private")
-      val path = config match {
-        case fileWithDir if config.hasPath("directory") => {
-          val fileString: String = fileWithDir[String]("file")
-          Datastore(privacy)
-            .directoryPath(
-              fileWithDir[String]("group"),
-              fileWithDir[String]("directory"),
-              fileWithDir[Int]("version")
-            )
-            .resolve(fileString)
+  def getLocalPathFromConfig(corpusConfig: Config): (Path, Boolean) = {
+    val directory = corpusConfig.get[String]("directory")
+    val file = corpusConfig.get[String]("file")
+    file match {
+      case Some(f) => {
+        directory match {
+          case Some(d) => (Paths.get(d, f), false)
+          case None => (Paths.get(f), false)
         }
-        case fileWithoutDir => Datastore(privacy).filePath(
-          fileWithoutDir[String]("group"),
-          fileWithoutDir[String]("file"),
-          fileWithoutDir[Int]("version")
-        )
       }
-      (path, config.get[String]("encoding").getOrElse("UTF-8"))
+      case None => (Paths.get(directory.get), true)
+    }
+  }
+
+  def getDatastorePathFromConfig(corpusConfig: Config): (Path, Boolean) = {
+    val directory = corpusConfig.get[String]("directory")
+    val file = corpusConfig.get[String]("file")
+    val privacy = corpusConfig.get[String]("privacy").getOrElse("private")
+    val group = corpusConfig[String]("group")
+    val version = corpusConfig[Int]("version")
+    file match {
+      case Some(f) => {
+        directory match {
+          case Some(d) => {
+            (Datastore(privacy).directoryPath(group, d, version).resolve(f), false)
+          }
+          case None => (Datastore(privacy).filePath(group, f, version), false)
+        }
+      }
+      case None => {
+        (Datastore(privacy).directoryPath(group, directory.get, version), true)
+      }
     }
   }
 }
-

--- a/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
@@ -202,9 +202,15 @@ class BuildCorpusIndex(config: Config) extends Logging {
   def segmentFile(file: File, codec: Codec, documentFormat: String): Iterator[String] = {
     documentFormat match {
       case "plain text" => segmentPlainTextFile(file, codec)
+      case "barrons" => getSegmentsFromDocument(new BarronsDocumentReader(file, codec).read())
       case "waterloo" => throw new IllegalStateException("you shouldn't have gotten here")
       case _ => throw new IllegalStateException("Unrecognized document format")
     }
+  }
+
+  def getSegmentsFromDocument(document: SegmentedDocument): Iterator[String] = {
+    val segments = document.getSegmentsOfType(indexType)
+    segments.map(_.getTextSegments.mkString(" ")).iterator
   }
 
   def segmentPlainTextFile(file: File, codec: Codec): Iterator[String] = {

--- a/indexing/src/main/scala/org/allenai/common/indexing/SegmentedDocument.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/SegmentedDocument.scala
@@ -4,11 +4,10 @@ import org.allenai.nlpstack.core.repr.Document
 
 import scala.collection.mutable
 
-/**
- * A document that has been broken up into (potentially nested) segments.  Note that there's a
- * notion of a segment and segmenter in the nlpstack, but those are used exclusively for sentences.
- * This class aims to capture higher-level document structure than sentences.
- */
+/** A document that has been broken up into (potentially nested) segments.  Note that there's a
+  * notion of a segment and segmenter in the nlpstack, but those are used exclusively for sentences.
+  * This class aims to capture higher-level document structure than sentences.
+  */
 class SegmentedDocument(text: String, val segments: Seq[Segment]) extends Document(text) {
   def getSegmentsOfType(segmentType: String): Seq[Segment] = {
     segments.flatMap(_.getSegmentsOfType(segmentType))
@@ -67,6 +66,6 @@ sealed abstract class Segment(segmentType: String) {
 }
 
 case class NonTerminalSegment(segmentType: String, segments: Seq[Segment])
-extends Segment(segmentType)
+  extends Segment(segmentType)
 
 case class TerminalSegment(segmentType: String, text: String) extends Segment(segmentType)

--- a/indexing/src/main/scala/org/allenai/common/indexing/SegmentedDocument.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/SegmentedDocument.scala
@@ -17,6 +17,8 @@ class SegmentedDocument(text: String, val segments: Seq[Segment]) extends Docume
     case that: SegmentedDocument => { that.text == this.text && that.segments == this.segments }
     case _ => false
   }
+
+  override def hashCode() = text.hashCode * 41 + segments.hashCode
 }
 
 class SegmentedDocumentBuilder(text: String) {
@@ -49,7 +51,11 @@ sealed abstract class Segment(segmentType: String) {
     this match {
       case NonTerminalSegment(sType, segments) => {
         val matchingSegmentsBelowMe = segments.flatMap(_.getSegmentsOfType(requestedType))
-        if (requestedType == sType) Seq(this) ++ matchingSegmentsBelowMe else matchingSegmentsBelowMe
+        if (requestedType == sType) {
+          Seq(this) ++ matchingSegmentsBelowMe
+        } else {
+          matchingSegmentsBelowMe
+        }
       }
       case TerminalSegment(sType, text) => {
         if (requestedType == sType) Seq(this) else Seq.empty[Segment]

--- a/indexing/src/main/scala/org/allenai/common/indexing/SegmentedDocument.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/SegmentedDocument.scala
@@ -1,0 +1,72 @@
+package org.allenai.common.indexing
+
+import org.allenai.nlpstack.core.repr.Document
+
+import scala.collection.mutable
+
+/**
+ * A document that has been broken up into (potentially nested) segments.  Note that there's a
+ * notion of a segment and segmenter in the nlpstack, but those are used exclusively for sentences.
+ * This class aims to capture higher-level document structure than sentences.
+ */
+class SegmentedDocument(text: String, val segments: Seq[Segment]) extends Document(text) {
+  def getSegmentsOfType(segmentType: String): Seq[Segment] = {
+    segments.flatMap(_.getSegmentsOfType(segmentType))
+  }
+
+  override def equals(that: Any) = that match {
+    case that: SegmentedDocument => { that.text == this.text && that.segments == this.segments }
+    case _ => false
+  }
+}
+
+class SegmentedDocumentBuilder(text: String) {
+  val finishedTopLevelSegments = new mutable.ListBuffer[Segment]
+  val segmentStack = new mutable.Stack[(String, mutable.ListBuffer[Segment])]
+
+  def startNewNonTerminalSegment(segmentType: String) {
+    segmentStack.push((segmentType, new mutable.ListBuffer[Segment]))
+  }
+
+  def finishNonTerminalSegment() {
+    val segmentToFinish = segmentStack.pop()
+    val finishedSegment = NonTerminalSegment(segmentToFinish._1, segmentToFinish._2.toSeq)
+    if (segmentStack.size == 0) {
+      finishedTopLevelSegments.append(finishedSegment)
+    } else {
+      segmentStack.top._2.append(finishedSegment)
+    }
+  }
+
+  def addTerminalSegment(segmentType: String, text: String) {
+    segmentStack.top._2.append(TerminalSegment(segmentType, text))
+  }
+
+  def build() = new SegmentedDocument(text, finishedTopLevelSegments.toSeq)
+}
+
+sealed abstract class Segment(segmentType: String) {
+  def getSegmentsOfType(requestedType: String): Seq[Segment] = {
+    this match {
+      case NonTerminalSegment(sType, segments) => {
+        val matchingSegmentsBelowMe = segments.flatMap(_.getSegmentsOfType(requestedType))
+        if (requestedType == sType) Seq(this) ++ matchingSegmentsBelowMe else matchingSegmentsBelowMe
+      }
+      case TerminalSegment(sType, text) => {
+        if (requestedType == sType) Seq(this) else Seq.empty[Segment]
+      }
+    }
+  }
+
+  def getTextSegments(): Seq[String] = {
+    this match {
+      case NonTerminalSegment(sType, segments) => segments.flatMap(_.getTextSegments)
+      case TerminalSegment(sType, text) => Seq(text)
+    }
+  }
+}
+
+case class NonTerminalSegment(segmentType: String, segments: Seq[Segment])
+extends Segment(segmentType)
+
+case class TerminalSegment(segmentType: String, text: String) extends Segment(segmentType)

--- a/indexing/src/test/scala/org/allenai/common/indexing/BarronsDocumentReaderSpec.scala
+++ b/indexing/src/test/scala/org/allenai/common/indexing/BarronsDocumentReaderSpec.scala
@@ -17,7 +17,8 @@ class BarronsDocumentReaderSpec extends UnitSpec {
     s"5.1.1.1.2.2\t${sentences(8)}",
     s"5.1.1.1.2.3\t${sentences(9)}",
     s"5.1.1.1.3.1\t${sentences(10)}",
-    s"5.1.1.1.3.2\t${sentences(11)}")
+    s"5.1.1.1.3.2\t${sentences(11)}"
+  )
 
   "read" should "get paragraphs out" in {
     val readDocument = new BarronsDocumentReader(null, "UTF-8")._readLines(sampleLines)
@@ -25,22 +26,26 @@ class BarronsDocumentReaderSpec extends UnitSpec {
       NonTerminalSegment("paragraph", Seq(
         TerminalSegment("sentence", sentences(0)),
         TerminalSegment("sentence", sentences(1)),
-        TerminalSegment("sentence", sentences(2)))),
+        TerminalSegment("sentence", sentences(2))
+      )),
       NonTerminalSegment("paragraph", Seq(
         TerminalSegment("sentence", sentences(3)),
         TerminalSegment("sentence", sentences(4)),
-        TerminalSegment("sentence", sentences(5)))),
+        TerminalSegment("sentence", sentences(5))
+      )),
       NonTerminalSegment("paragraph", Seq(
-        TerminalSegment("sentence", sentences(6)))),
+        TerminalSegment("sentence", sentences(6))
+      )),
       NonTerminalSegment("paragraph", Seq(
         TerminalSegment("sentence", sentences(7)),
         TerminalSegment("sentence", sentences(8)),
-        TerminalSegment("sentence", sentences(9)))),
+        TerminalSegment("sentence", sentences(9))
+      )),
       NonTerminalSegment("paragraph", Seq(
         TerminalSegment("sentence", sentences(10)),
-        TerminalSegment("sentence", sentences(11))))
-      )
-    )
+        TerminalSegment("sentence", sentences(11))
+      ))
+    ))
     readDocument should be(expectedDocument)
   }
 }

--- a/indexing/src/test/scala/org/allenai/common/indexing/BarronsDocumentReaderSpec.scala
+++ b/indexing/src/test/scala/org/allenai/common/indexing/BarronsDocumentReaderSpec.scala
@@ -1,0 +1,47 @@
+package org.allenai.common.indexing
+
+import org.allenai.common.testkit.UnitSpec
+
+class BarronsDocumentReaderSpec extends UnitSpec {
+
+  val sentences = (0 to 20).map("sentence " + _)
+  val sampleLines = Seq(
+    s"5.1.1.1.1\t${sentences(0)}",
+    s"5.1.1.1.2\t${sentences(1)}",
+    s"5.1.1.1.3\t${sentences(2)}",
+    s"5.1.1.2.1\t${sentences(3)}",
+    s"5.1.1.2.2\t${sentences(4)}",
+    s"5.1.1.2.3\t${sentences(5)}",
+    s"5.1.1.1.1.1\t${sentences(6)}",
+    s"5.1.1.1.2.1\t${sentences(7)}",
+    s"5.1.1.1.2.2\t${sentences(8)}",
+    s"5.1.1.1.2.3\t${sentences(9)}",
+    s"5.1.1.1.3.1\t${sentences(10)}",
+    s"5.1.1.1.3.2\t${sentences(11)}")
+
+  "read" should "get paragraphs out" in {
+    val readDocument = new BarronsDocumentReader(null, "UTF-8")._readLines(sampleLines)
+    val expectedDocument = new SegmentedDocument(sampleLines.mkString("\n"), Seq(
+      NonTerminalSegment("paragraph", Seq(
+        TerminalSegment("sentence", sentences(0)),
+        TerminalSegment("sentence", sentences(1)),
+        TerminalSegment("sentence", sentences(2)))),
+      NonTerminalSegment("paragraph", Seq(
+        TerminalSegment("sentence", sentences(3)),
+        TerminalSegment("sentence", sentences(4)),
+        TerminalSegment("sentence", sentences(5)))),
+      NonTerminalSegment("paragraph", Seq(
+        TerminalSegment("sentence", sentences(6)))),
+      NonTerminalSegment("paragraph", Seq(
+        TerminalSegment("sentence", sentences(7)),
+        TerminalSegment("sentence", sentences(8)),
+        TerminalSegment("sentence", sentences(9)))),
+      NonTerminalSegment("paragraph", Seq(
+        TerminalSegment("sentence", sentences(10)),
+        TerminalSegment("sentence", sentences(11))))
+      )
+    )
+    readDocument should be(expectedDocument)
+  }
+}
+

--- a/indexing/src/test/scala/org/allenai/common/indexing/BuildCorpusIndexSpec.scala
+++ b/indexing/src/test/scala/org/allenai/common/indexing/BuildCorpusIndexSpec.scala
@@ -34,7 +34,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
         case Some(d) => s"/${file}"
         case None => {
           val (base, extension) = file.splitAt(file.lastIndexOf("."))
-          s"${base}-v${version}.${extension}"
+          s"${base}-v${version}${extension}"
         }
       }
       Paths.get(s"/fake/cache/dir/org.allenai.datastore/${privacy}/${group}/${d}${f}")
@@ -44,7 +44,9 @@ class BuildCorpusIndexSpec extends UnitSpec {
       group: String,
       directory: String,
       version: Int
-    ): Path = { Paths.get(s"/fake/dir/org.allenai.datastore/${privacy}/${group}/${directory}") }
+    ): Path = {
+      Paths.get(s"/fake/dir/org.allenai.datastore/${privacy}/${group}/${directory}-d${version}")
+    }
   }
   val dir1 = "/test/path/dir1/"
   val file1 = "test/file1"
@@ -104,7 +106,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
       |version: 1
       |privacy: "public"
       |}""".stripMargin)
-    val parsed = buildCorpusIndex.parseCorpusConfig(corpusConfig)
+    val parsed = bciWithMockedDatastore.parseCorpusConfig(corpusConfig)
     expectParse(
       parsed,
       "org.allenai.datastore/public/org.allenai.corpora.wikipedia/" +
@@ -121,7 +123,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
       |directory: "Barrons-4thGrade.sentences"
       |version: 1
       |}""".stripMargin)
-    val parsed = buildCorpusIndex.parseCorpusConfig(corpusConfig)
+    val parsed = bciWithMockedDatastore.parseCorpusConfig(corpusConfig)
     expectParse(
       parsed,
       "org.allenai.datastore/private/org.allenai.aristo.corpora.derivative/" +
@@ -140,7 +142,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
       |encoding: "fake encoding"
       |version: 1
       |}""".stripMargin)
-    val parsed = buildCorpusIndex.parseCorpusConfig(corpusConfig)
+    val parsed = bciWithMockedDatastore.parseCorpusConfig(corpusConfig)
     expectParse(
       parsed,
       "org.allenai.datastore/private/org.allenai.aristo.corpora.derivative/" +

--- a/indexing/src/test/scala/org/allenai/common/indexing/BuildCorpusIndexSpec.scala
+++ b/indexing/src/test/scala/org/allenai/common/indexing/BuildCorpusIndexSpec.scala
@@ -3,10 +3,49 @@ package org.allenai.common.indexing
 import org.allenai.common.testkit.UnitSpec
 
 import com.typesafe.config.{ ConfigFactory, Config }
-import java.nio.file.Paths
+import java.nio.file.{ Path, Paths }
 
 class BuildCorpusIndexSpec extends UnitSpec {
 
+  val baseConfig = ConfigFactory.parseString("""
+    elasticSearch: {
+      indexName: "dummy name"
+      indexType: "dummy type"
+    }
+    buildIndexOptions: {
+      dumpFolder: "dummy folder"
+    }
+    """)
+  val buildCorpusIndex = new BuildCorpusIndex(baseConfig)
+
+  // It's unfortunate that I need to write these methods, but this was the only way I found to
+  // reasonably test the datastore stuff.  It would be better to just be able to pass in a fake
+  // datastore, but the calls to Datastore are static...
+  val bciWithMockedDatastore = new BuildCorpusIndex(baseConfig) {
+    override def getFileFromDatastore(
+      privacy: String,
+      group: String,
+      directory: Option[String],
+      file: String,
+      version: Int
+    ): Path = {
+      val d = directory match { case Some(d) => d + s"-d${version}"; case None => "" }
+      val f = directory match {
+        case Some(d) => s"/${file}"
+        case None => {
+          val (base, extension) = file.splitAt(file.lastIndexOf("."))
+          s"${base}-v${version}.${extension}"
+        }
+      }
+      Paths.get(s"/fake/cache/dir/org.allenai.datastore/${privacy}/${group}/${d}${f}")
+    }
+    override def getDirectoryFromDatastore(
+      privacy: String,
+      group: String,
+      directory: String,
+      version: Int
+    ): Path = { Paths.get(s"/fake/dir/org.allenai.datastore/${privacy}/${group}/${directory}") }
+  }
   val dir1 = "/test/path/dir1/"
   val file1 = "test/file1"
 
@@ -34,7 +73,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
       |directory: "${dir1}"
       |}""".stripMargin)
     val expectedParse = ParsedConfig(Paths.get(dir1), true, "UTF-8", "waterloo")
-    BuildCorpusIndex.parseCorpusConfig(corpusConfig) should be(expectedParse)
+    buildCorpusIndex.parseCorpusConfig(corpusConfig) should be(expectedParse)
   }
 
   it should "parse a local file with directory" in {
@@ -45,7 +84,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
       |file: "${file1}"
       |}""".stripMargin)
     val expectedConfig = ParsedConfig(Paths.get(dir1, file1), false, "UTF-8", "waterloo")
-    BuildCorpusIndex.parseCorpusConfig(corpusConfig) should be(expectedConfig)
+    buildCorpusIndex.parseCorpusConfig(corpusConfig) should be(expectedConfig)
   }
 
   it should "parse a local file without a directory" in {
@@ -55,7 +94,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
       |file: "${file1}"
       |}""".stripMargin)
     val expectedConfig = ParsedConfig(Paths.get(file1), false, "UTF-8", "waterloo")
-    BuildCorpusIndex.parseCorpusConfig(corpusConfig) should be(expectedConfig)
+    buildCorpusIndex.parseCorpusConfig(corpusConfig) should be(expectedConfig)
   }
 
   it should "parse a datastore file" in {
@@ -65,7 +104,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
       |version: 1
       |privacy: "public"
       |}""".stripMargin)
-    val parsed = BuildCorpusIndex.parseCorpusConfig(corpusConfig)
+    val parsed = buildCorpusIndex.parseCorpusConfig(corpusConfig)
     expectParse(
       parsed,
       "org.allenai.datastore/public/org.allenai.corpora.wikipedia/" +
@@ -82,7 +121,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
       |directory: "Barrons-4thGrade.sentences"
       |version: 1
       |}""".stripMargin)
-    val parsed = BuildCorpusIndex.parseCorpusConfig(corpusConfig)
+    val parsed = buildCorpusIndex.parseCorpusConfig(corpusConfig)
     expectParse(
       parsed,
       "org.allenai.datastore/private/org.allenai.aristo.corpora.derivative/" +
@@ -101,7 +140,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
       |encoding: "fake encoding"
       |version: 1
       |}""".stripMargin)
-    val parsed = BuildCorpusIndex.parseCorpusConfig(corpusConfig)
+    val parsed = buildCorpusIndex.parseCorpusConfig(corpusConfig)
     expectParse(
       parsed,
       "org.allenai.datastore/private/org.allenai.aristo.corpora.derivative/" +

--- a/indexing/src/test/scala/org/allenai/common/indexing/BuildCorpusIndexSpec.scala
+++ b/indexing/src/test/scala/org/allenai/common/indexing/BuildCorpusIndexSpec.scala
@@ -1,0 +1,113 @@
+package org.allenai.common.indexing
+
+import org.allenai.common.testkit.UnitSpec
+
+import com.typesafe.config.{ ConfigFactory, Config }
+import java.nio.file.Paths
+
+class BuildCorpusIndexSpec extends UnitSpec {
+
+  val dir1 = "/test/path/dir1/"
+  val file1 = "test/file1"
+
+  /**
+   * Test an given parse result against expected results.  We need to test like this when we're
+   * accessing something from the Datastore, because we have to check a suffix on the file path,
+   * instead of just checking for object equality.
+   */
+  def expectParse(
+    parsedConfig: ParsedConfig,
+    pathSuffix: String,
+    isDirectory: Boolean,
+    encoding: String,
+    documentFormat: String
+  ) {
+    parsedConfig.path.toString should endWith(pathSuffix)
+    parsedConfig.isDirectory should be(isDirectory)
+    parsedConfig.encoding should be(encoding)
+    parsedConfig.documentFormat should be(documentFormat)
+  }
+
+
+  "parseCorpusConfig" should "parse a local directory" in {
+    val corpusConfig = ConfigFactory.parseString(s"""{
+      |pathIsLocal: true
+      |documentFormat: "waterloo"
+      |directory: "${dir1}"
+      |}""".stripMargin)
+    val expectedParse = ParsedConfig(Paths.get(dir1), true, "UTF-8", "waterloo")
+    BuildCorpusIndex.parseCorpusConfig(corpusConfig) should be(expectedParse)
+  }
+
+  it should "parse a local file with directory" in {
+    val corpusConfig = ConfigFactory.parseString(s"""{
+      |pathIsLocal: true
+      |documentFormat: "waterloo"
+      |directory: "${dir1}"
+      |file: "${file1}"
+      |}""".stripMargin)
+    val expectedConfig = ParsedConfig(Paths.get(dir1, file1), false, "UTF-8", "waterloo")
+    BuildCorpusIndex.parseCorpusConfig(corpusConfig) should be(expectedConfig)
+  }
+
+  it should "parse a local file without a directory" in {
+    val corpusConfig = ConfigFactory.parseString(s"""{
+      |pathIsLocal: true
+      |documentFormat: "waterloo"
+      |file: "${file1}"
+      |}""".stripMargin)
+    val expectedConfig = ParsedConfig(Paths.get(file1), false, "UTF-8", "waterloo")
+    BuildCorpusIndex.parseCorpusConfig(corpusConfig) should be(expectedConfig)
+  }
+
+  it should "parse a datastore file" in {
+    val corpusConfig = ConfigFactory.parseString(s"""{
+      |group: "org.allenai.corpora.wikipedia"
+      |file: "simple_wikipedia_first_few_articles.txt"
+      |version: 1
+      |privacy: "public"
+      |}""".stripMargin)
+    val parsed = BuildCorpusIndex.parseCorpusConfig(corpusConfig)
+    expectParse(
+      parsed,
+      "org.allenai.datastore/public/org.allenai.corpora.wikipedia/" +
+        "simple_wikipedia_first_few_articles-v1.txt",
+      false,
+      "UTF-8",
+      "plain text")
+  }
+
+  it should "parse a datastore directory" in {
+    val corpusConfig = ConfigFactory.parseString(s"""{
+      |group: "org.allenai.aristo.corpora.derivative"
+      |directory: "Barrons-4thGrade.sentences"
+      |version: 1
+      |}""".stripMargin)
+    val parsed = BuildCorpusIndex.parseCorpusConfig(corpusConfig)
+    expectParse(
+      parsed,
+      "org.allenai.datastore/private/org.allenai.aristo.corpora.derivative/" +
+        "Barrons-4thGrade.sentences-d1",
+      true,
+      "UTF-8",
+      "plain text")
+  }
+
+  it should "parse a datastore file with a directory" in {
+    val corpusConfig = ConfigFactory.parseString(s"""{
+      |group: "org.allenai.aristo.corpora.derivative"
+      |directory: "Barrons-4thGrade.sentences"
+      |file: "Barrons-5.sentences.txt"
+      |encoding: "fake encoding"
+      |version: 1
+      |}""".stripMargin)
+    val parsed = BuildCorpusIndex.parseCorpusConfig(corpusConfig)
+    expectParse(
+      parsed,
+      "org.allenai.datastore/private/org.allenai.aristo.corpora.derivative/" +
+        "Barrons-4thGrade.sentences-d1/Barrons-5.sentences.txt",
+      false,
+      "fake encoding",
+      "plain text")
+  }
+}

--- a/indexing/src/test/scala/org/allenai/common/indexing/BuildCorpusIndexSpec.scala
+++ b/indexing/src/test/scala/org/allenai/common/indexing/BuildCorpusIndexSpec.scala
@@ -10,11 +10,10 @@ class BuildCorpusIndexSpec extends UnitSpec {
   val dir1 = "/test/path/dir1/"
   val file1 = "test/file1"
 
-  /**
-   * Test an given parse result against expected results.  We need to test like this when we're
-   * accessing something from the Datastore, because we have to check a suffix on the file path,
-   * instead of just checking for object equality.
-   */
+  /** Test an given parse result against expected results.  We need to test like this when we're
+    * accessing something from the Datastore, because we have to check a suffix on the file path,
+    * instead of just checking for object equality.
+    */
   def expectParse(
     parsedConfig: ParsedConfig,
     pathSuffix: String,
@@ -27,7 +26,6 @@ class BuildCorpusIndexSpec extends UnitSpec {
     parsedConfig.encoding should be(encoding)
     parsedConfig.documentFormat should be(documentFormat)
   }
-
 
   "parseCorpusConfig" should "parse a local directory" in {
     val corpusConfig = ConfigFactory.parseString(s"""{
@@ -74,7 +72,8 @@ class BuildCorpusIndexSpec extends UnitSpec {
         "simple_wikipedia_first_few_articles-v1.txt",
       false,
       "UTF-8",
-      "plain text")
+      "plain text"
+    )
   }
 
   it should "parse a datastore directory" in {
@@ -90,7 +89,8 @@ class BuildCorpusIndexSpec extends UnitSpec {
         "Barrons-4thGrade.sentences-d1",
       true,
       "UTF-8",
-      "plain text")
+      "plain text"
+    )
   }
 
   it should "parse a datastore file with a directory" in {
@@ -108,6 +108,7 @@ class BuildCorpusIndexSpec extends UnitSpec {
         "Barrons-4thGrade.sentences-d1/Barrons-5.sentences.txt",
       false,
       "fake encoding",
-      "plain text")
+      "plain text"
+    )
   }
 }

--- a/indexing/src/test/scala/org/allenai/common/indexing/SegmentedDocumentSpec.scala
+++ b/indexing/src/test/scala/org/allenai/common/indexing/SegmentedDocumentSpec.scala
@@ -20,7 +20,9 @@ class SegmentedDocumentSpec extends UnitSpec {
     chapter1.getSegmentsOfType("chapter") should be(Seq(chapter1))
     chapter1.getSegmentsOfType("section") should be(Seq(section1, section2))
     chapter1.getSegmentsOfType("paragraph") should be(Seq(paragraph1, paragraph2, paragraph3))
-    chapter1.getSegmentsOfType("sentence") should be(Seq(sentence1, sentence2, sentence3, sentence4))
+    chapter1.getSegmentsOfType("sentence") should be(
+      Seq(sentence1, sentence2, sentence3, sentence4)
+    )
   }
 
   "Segment.getTextSegments" should "recursively get text from all terminal segments" in {
@@ -40,7 +42,9 @@ class SegmentedDocumentSpec extends UnitSpec {
     document.getSegmentsOfType("chapter") should be(Seq(chapter1))
     document.getSegmentsOfType("section") should be(Seq(section1, section2))
     document.getSegmentsOfType("paragraph") should be(Seq(paragraph1, paragraph2, paragraph3))
-    document.getSegmentsOfType("sentence") should be(Seq(sentence1, sentence2, sentence3, sentence4))
+    document.getSegmentsOfType("sentence") should be(
+      Seq(sentence1, sentence2, sentence3, sentence4)
+    )
   }
 
   "SegmentedDocumentBuilder" should "correctly build a segmented document" in {

--- a/indexing/src/test/scala/org/allenai/common/indexing/SegmentedDocumentSpec.scala
+++ b/indexing/src/test/scala/org/allenai/common/indexing/SegmentedDocumentSpec.scala
@@ -1,0 +1,67 @@
+package org.allenai.common.indexing
+
+import org.allenai.common.testkit.UnitSpec
+
+class SegmentedDocumentSpec extends UnitSpec {
+
+  val sentence1 = TerminalSegment("sentence", "sentence1")
+  val sentence2 = TerminalSegment("sentence", "sentence2")
+  val sentence3 = TerminalSegment("sentence", "sentence3")
+  val sentence4 = TerminalSegment("sentence", "sentence4")
+  val paragraph1 = NonTerminalSegment("paragraph", Seq(sentence1, sentence2))
+  val paragraph2 = NonTerminalSegment("paragraph", Seq(sentence3))
+  val paragraph3 = NonTerminalSegment("paragraph", Seq(sentence4))
+  val section1 = NonTerminalSegment("section", Seq(paragraph1))
+  val section2 = NonTerminalSegment("section", Seq(paragraph2, paragraph3))
+  val chapter1 = NonTerminalSegment("chapter", Seq(section1, section2))
+  val document = new SegmentedDocument("dummy text", Seq(chapter1))
+
+  "Segment.getSegmentsOfType" should "recursively get all segments of the correct type" in {
+    chapter1.getSegmentsOfType("chapter") should be(Seq(chapter1))
+    chapter1.getSegmentsOfType("section") should be(Seq(section1, section2))
+    chapter1.getSegmentsOfType("paragraph") should be(Seq(paragraph1, paragraph2, paragraph3))
+    chapter1.getSegmentsOfType("sentence") should be(Seq(sentence1, sentence2, sentence3, sentence4))
+  }
+
+  "Segment.getTextSegments" should "recursively get text from all terminal segments" in {
+    chapter1.getTextSegments() should be(Seq("sentence1", "sentence2", "sentence3", "sentence4"))
+    section1.getTextSegments() should be(Seq("sentence1", "sentence2"))
+    section2.getTextSegments() should be(Seq("sentence3", "sentence4"))
+    paragraph1.getTextSegments() should be(Seq("sentence1", "sentence2"))
+    paragraph2.getTextSegments() should be(Seq("sentence3"))
+    paragraph3.getTextSegments() should be(Seq("sentence4"))
+    sentence1.getTextSegments() should be(Seq("sentence1"))
+    sentence2.getTextSegments() should be(Seq("sentence2"))
+    sentence3.getTextSegments() should be(Seq("sentence3"))
+    sentence4.getTextSegments() should be(Seq("sentence4"))
+  }
+
+  "SegmentedDocument.getSegmentsOfType" should "get all segments of the correct type" in {
+    document.getSegmentsOfType("chapter") should be(Seq(chapter1))
+    document.getSegmentsOfType("section") should be(Seq(section1, section2))
+    document.getSegmentsOfType("paragraph") should be(Seq(paragraph1, paragraph2, paragraph3))
+    document.getSegmentsOfType("sentence") should be(Seq(sentence1, sentence2, sentence3, sentence4))
+  }
+
+  "SegmentedDocumentBuilder" should "correctly build a segmented document" in {
+    val builder = new SegmentedDocumentBuilder("dummy text")
+    builder.startNewNonTerminalSegment("chapter")
+    builder.startNewNonTerminalSegment("section")
+    builder.startNewNonTerminalSegment("paragraph")
+    builder.addTerminalSegment("sentence", "sentence1")
+    builder.addTerminalSegment("sentence", "sentence2")
+    builder.finishNonTerminalSegment()
+    builder.finishNonTerminalSegment()
+    builder.startNewNonTerminalSegment("section")
+    builder.startNewNonTerminalSegment("paragraph")
+    builder.addTerminalSegment("sentence", "sentence3")
+    builder.finishNonTerminalSegment()
+    builder.startNewNonTerminalSegment("paragraph")
+    builder.addTerminalSegment("sentence", "sentence4")
+    builder.finishNonTerminalSegment()
+    builder.finishNonTerminalSegment()
+    builder.finishNonTerminalSegment()
+
+    builder.build() should be(document)
+  }
+}


### PR DESCRIPTION
The biggest change here is in BuildCorpusIndex.scala.  There used to be three paths through the code for three different corpus specifications, with a lot of code duplicated between those three paths.  I merged them into a single code path, where first you determine what kind of a corpus to index (local vs. from the datastore, what the document format is), then you process the file according to its document format.

After this refactoring, I added some new document formats that permit segmenting by paragraph instead of by sentence.  I have run this locally for the Barron's study guide and for simple wikipedia (both by sentence, to make sure that still works, and the new paragraph indexing), and it works for me.  I didn't run it on the waterloo corpus or full wikipedia, because I thought it was too big for my laptop to handle, and I don't know how to use EC2 for this.

Part of the new document format stuff involves a new document representation, SegmentedDocument.  This isn't a perfect document representation, but it's good enough for what I needed.  I'm not sure if this is the right place to put this class, but it does seem rather specific to the indexing code.

I also added tests for most of the code that I touched.