### PR TITLE
Release 1.2.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.0"
+version in ThisBuild := "1.2.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.7-SNAPSHOT"
+version in ThisBuild := "1.2.0"


### PR DESCRIPTION
Decided to bump the minor version since moving the cache out of common-core could cause headaches for anyone caught off-guard.