### PR TITLE
Add a binding for ActorRefFactory.

### DIFF
--- a/guice/src/main/scala/org/allenai/common/guice/ActorSystemModule.scala
+++ b/guice/src/main/scala/org/allenai/common/guice/ActorSystemModule.scala
@@ -1,11 +1,12 @@
 package org.allenai.common.guice
 
-import akka.actor.ActorSystem
+import akka.actor.{ ActorRefFactory, ActorSystem }
 import net.codingwell.scalaguice.ScalaModule
 
 import scala.concurrent.ExecutionContext
 
-/** Module that binds an ActorSystem and its associated ExecutionContext.
+/** Module that binds ActorSystem and its associated ExecutionContext. The ActorSystem will also be
+  * bound to ActorRefFactory.
   * @param bindingName optional name to create the bindings under
   * @param actorSystem the actor system to bind
   */
@@ -14,10 +15,12 @@ class ActorSystemModule(bindingName: Option[String] = None)(implicit actorSystem
   override def configure(): Unit = {
     bindingName match {
       case Some(name) => {
+        bind[ActorRefFactory].annotatedWithName(name).toInstance(actorSystem)
         bind[ActorSystem].annotatedWithName(name).toInstance(actorSystem)
         bind[ExecutionContext].annotatedWithName(name).toInstance(actorSystem.dispatcher)
       }
       case None => {
+        bind[ActorRefFactory].toInstance(actorSystem)
         bind[ActorSystem].toInstance(actorSystem)
         bind[ExecutionContext].toInstance(actorSystem.dispatcher)
       }


### PR DESCRIPTION
Suh guicey.

Sometimes all you need is the `ActorRefFactory`, and not the full `ActorSystem`. spray-routing's `compressResponseIfRequested` directive is a good example of an API which requires the factory, but not the full system.