### PR TITLE
Make enum serialization more automatic.

### DIFF
--- a/core/src/test/scala/org/allenai/common/EnumSpec.scala
+++ b/core/src/test/scala/org/allenai/common/EnumSpec.scala
@@ -18,9 +18,9 @@ class EnumSpec extends UnitSpec {
   }
 
   "withId" should "retrieve correct Enum" in {
-    assert(FakeEnum.withId("value1") === FakeEnum.Value1)
-    assert(FakeEnum.withId("value2") === FakeEnum.Value2)
-    assert(FakeEnum.withId("value3") === FakeEnum.Value3)
+    assert(FakeEnum.withId("Value1") === FakeEnum.Value1)
+    assert(FakeEnum.withId("Value2") === FakeEnum.Value2)
+    assert(FakeEnum.withId("Value3") === FakeEnum.Value3)
   }
 
   it should "throw NoSuchElementException" in {
@@ -30,7 +30,7 @@ class EnumSpec extends UnitSpec {
   }
 
   "toString" should "act like builtin Enumeration" in {
-    assert(FakeEnum.Value1.toString === "value1")
+    assert(FakeEnum.Value1.toString === "Value1")
   }
 
   "JSON serialization" should "work" in {
@@ -59,10 +59,10 @@ class EnumSpec extends UnitSpec {
 
 // Test enum. Must be defined outside of spec otherwise serialization tests will
 // fail due to scalatest WordSpec not being serializable.
-sealed abstract class FakeEnum(name: String) extends Enum[FakeEnum](name)
+sealed abstract class FakeEnum extends Enum[FakeEnum]
 object FakeEnum extends EnumCompanion[FakeEnum] {
-  case object Value1 extends FakeEnum("value1")
-  case object Value2 extends FakeEnum("value2")
-  case object Value3 extends FakeEnum("value3")
+  case object Value1 extends FakeEnum
+  case object Value2 extends FakeEnum
+  case object Value3 extends FakeEnum
   register(Value1, Value2, Value3)
 }


### PR DESCRIPTION
This uses the `toString` as the serialization value (by default). This reduces the boilerplate when specifying enum values, and prevents errors introduced by accidentally using the same `id` string twice, like in:
```scala
case object MyValue1 extends MyEnum("value1")
case object MyValue2 extends MyEnum("value1") // whoops!
```
The one thing that I considered, but didn't include, is adding a self-type of `Product` to the `Enum` mixin. It's not technically required; `toString` exists on `Any`. However, the self-type encourages you to use `case object`s for the enum values (you can technically use any `case class` or even `Tuple`, but that requires some serious effort). It also reduces the potential for bugs in migrating from the old version.

On the downside, it requires a self-type (or extending `Product`) on the abstract parent class:
```scala
// Using a self-type:
abstract class Enum[E <: Enum[E]] { self: Product =>
  // etc.
}
// Additional boilerplate:
sealed abstract class MyEnum extends Enum[MyEnum] { self: Product => }
```
Mostly I worry that the protection it gives is basically nil, but it adds some annoyance to usage. If there were a `Product0` or similar class that only `case object`s extended I would use that, but there isn't AFAICT.