### PR TITLE
Index Quizlet and Studystack

### DIFF
--- a/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
@@ -75,6 +75,67 @@ org.allenai.common.indexing.paragraph_base: ${org.allenai.common.indexing.base} 
   }
 }
 
+org.allenai.common.indexing.qa_base: ${org.allenai.common.indexing.base} {
+  elasticSearch: {
+    indexType: "sentence"
+    mapping: {
+      sentence: {
+        dynamic: false,
+        properties: {
+          question: {
+            type: "string",
+            analyzer: "snowball", 
+            fields: {
+              raw: {type: "string", index: "not_analyzed"}
+            }
+          }
+          answer: {
+            type: "string",
+            analyzer: "snowball",
+            fields: {
+              raw: {type: "string", index: "not_analyzed"}
+            }
+          }
+          source: {
+            type: "string",
+            index: "not_analyzed"
+          }
+        }
+      }
+    }
+  }
+}
+
+org.allenai.common.indexing.termdef_base: ${org.allenai.common.indexing.base} {
+  elasticSearch: {
+    indexType: "sentence"
+    mapping: {
+      sentence: {
+        dynamic: false,
+        properties: {
+          term: {
+            type: "string",
+            analyzer: "snowball",
+            fields: {
+              raw: {type: "string", index: "not_analyzed"}
+            }
+          }
+          definition: {
+            type: "string",
+            analyzer: "snowball",
+            fields: {
+              raw: {type: "string", index: "not_analyzed"}
+            }
+          }
+          source: {
+            type: "string",
+            index: "not_analyzed"
+          }
+        }
+      }
+    }
+  }
+}
 
 org.allenai.common.indexing.waterloo: ${org.allenai.common.indexing.sentence_base} {
   elasticSearch.indexName: "waterloo"
@@ -196,3 +257,56 @@ org.allenai.common.indexing.barrons_paragraph: ${org.allenai.common.indexing.par
     }
   ]
 }
+
+org.allenai.common.indexing.quizlet_qna: ${org.allenai.common.indexing.qa_base} {
+  elasticSearch.indexName: "quizlet-qna"
+  corpora: [
+    {
+      documentFormat: "question-answer"
+      group: "org.allenai.aristo.corpora.derivative"
+      directory:  "QuizletQnA"
+      version: 1
+      file: "QuizletQnA.txt"
+    }
+  ]
+}
+
+org.allenai.common.indexing.quizlet_termdef: ${org.allenai.common.indexing.termdef_base} {
+  elasticSearch.indexName: "quizlet-termdef"
+  corpora: [
+    {
+      documentFormat: "term-definition"
+      group: "org.allenai.aristo.corpora.derivative"
+      directory:  "QuizletTermDefinitions"
+      version: 1
+      file: "QuizletTermDefinitions.txt"
+    }
+  ]
+}
+
+org.allenai.common.indexing.studystack_qna: ${org.allenai.common.indexing.qa_base} {
+  elasticSearch.indexName: "studystack-qna"
+  corpora: [
+    {
+      documentFormat: "question-answer"
+      group: "org.allenai.aristo.corpora.derivative"
+      directory:  "StudyStackQnA"
+      version: 1
+      file: "StudyStackQnA.txt"
+    }
+  ]
+}
+
+org.allenai.common.indexing.studystack_termdef: ${org.allenai.common.indexing.termdef_base} {
+  elasticSearch.indexName: "studystack-termdef"
+  corpora: [
+    {
+      documentFormat: "term-definition"
+      group: "org.allenai.aristo.corpora.derivative"
+      directory:  "StudyStackTermDefinitions"
+      version: 1
+      file: "StudyStackTermDefinitions.txt"
+    }
+  ]
+}
+

--- a/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
@@ -77,9 +77,9 @@ org.allenai.common.indexing.paragraph_base: ${org.allenai.common.indexing.base} 
 
 org.allenai.common.indexing.qa_base: ${org.allenai.common.indexing.base} {
   elasticSearch: {
-    indexType: "sentence"
+    indexType: "question-answer"
     mapping: {
-      sentence: {
+      question-answer: {
         dynamic: false,
         properties: {
           question: {
@@ -108,9 +108,9 @@ org.allenai.common.indexing.qa_base: ${org.allenai.common.indexing.base} {
 
 org.allenai.common.indexing.termdef_base: ${org.allenai.common.indexing.base} {
   elasticSearch: {
-    indexType: "sentence"
+    indexType: "term-definition"
     mapping: {
-      sentence: {
+      term-definition: {
         dynamic: false,
         properties: {
           term: {

--- a/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
@@ -216,9 +216,6 @@ class BuildCorpusIndex(config: Config) extends Logging {
   }
 
   def segmentPlainTextFile(file: File, codec: Codec): Iterator[String] = {
-    if (indexType != "sentence") {
-      throw new IllegalStateException("plain text can only be segmented into sentences")
-    }
     val bufSource = Source.fromFile(file, 8192)(codec)
     val lines = bufSource.getLines
     (lines flatMap { defaultSegmenter.segmentTexts })
@@ -252,9 +249,9 @@ class BuildCorpusIndex(config: Config) extends Logging {
   ): Unit = {
     // Helper Function
     def breakQAline(line: String): Option[(String, String)] = {
-      line.split(""":\|:""") match {
-        case Array(lhs, rhs, _*) if (!lhs.trim.isEmpty() && !rhs.trim.isEmpty()) =>
-          Some((lhs.trim, rhs.trim))
+      line.split(""":\|:""").map(_.trim) match {
+        case Array(lhs, rhs, _*) if (!lhs.isEmpty() && !rhs.isEmpty()) =>
+          Some((lhs, rhs))
         case _ => None
       }
     }


### PR DESCRIPTION
@ColinArenz : Each of these corpora was split into two -- one containing `question:|:answer` pairs and the other containing `term:|:definition` pairs, one per line. This code indexes the corpora with two fields instead of a single `text` field like we do for our other Aristo corpora.
