### PR TITLE
Clean up ElasticSearch index mappings

### DIFF
--- a/indexing/README.md
+++ b/indexing/README.md
@@ -11,18 +11,17 @@ Once you have ElasticSearch, go to the `bin` directory and run: `./elasticsearch
 Configurations are of the form:
 
 ```
-org.allenai.common.indexing.[NAME_OF_INDEX] 
+org.allenai.common.indexing.[NAME_OF_INDEX]
 
       elasticSearch {
         clusterName: [CLUSTER_NAME]
-        hostIp: "127.0.0.1"
-        hostPort: 9300
-        indexName:[NAME_OF_INDEX]
+        hostAddress: "127.0.0.1"
+        indexName: [NAME_OF_INDEX]
         indexType: "sentence"
-    
+
         mapping = ${org.allenai.common.indexing.standardMapping}
       }
-    
+
       buildIndexOptions {
         // If set to true will throw an exception if the index already exists
         // NOTE: if set to false, and a document already exists in the index, will create a duplicate document
@@ -31,7 +30,7 @@ org.allenai.common.indexing.[NAME_OF_INDEX]
         // specifies where to dump serialized failed bulk index requests
         dumpFolder: "[PATH_TO_DUMP]"
       }
-    
+
         // Template list of corpora
       corpora: [
         {
@@ -86,4 +85,3 @@ Without Config Overrides:
 ```
 sbt "indexing/runMain org.allenai.common.indexing.BuildCorpusIndexRunner --index-name barrons"
 ```
-

--- a/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
@@ -1,24 +1,24 @@
 include "mappingHelpers.conf"
 
-org.allenai.common.indexing {
-  stoplist {
-    group: "org.allenai.nlp.resources"
-    name: "smart_stopwords_2.txt"
-    version: 1
-  }
+org.allenai.common.indexing.stoplist {
+  group: "org.allenai.nlp.resources"
+  name: "smart_stopwords_2.txt"
+  version: 1
 }
 
 org.allenai.common.indexing.base {
   elasticSearch {
-    // Specify the right clustername. It usually defaults to `elasticsearch` but
-    // you can verify by using the command:
-    // curl -XGET 'http://localhost:9200/_cluster/health?pretty=true'.
-    // For Aristo Solvers, the hostIp should be changed to `aristo-es.dev.ai2`
-    // with clusterName `aristo-es`.
-    clusterName: "elasticsearch"
-    hostIp: "127.0.0.1"
+    hostAddress: "127.0.0.1"
     hostPort: 9300
+
+    // Your cluster name can be obtained with the following command.
+    // curl -XGET 'http://<hostAddress>:9200/_cluster/health?pretty=true'.
+    clusterName: "elasticsearch"
     indexName: "lucene"
+
+    // Aristo should override the following values:
+    //clusterName: "aristo-es"
+    //hostAddress: "aristo-es.dev.ai2"
   }
 
   buildIndexOptions {

--- a/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
@@ -1,19 +1,19 @@
-org.allenai.common.indexing: {
+include "mappingHelpers.conf"
 
-  stoplist: {
+org.allenai.common.indexing {
+  stoplist {
     group: "org.allenai.nlp.resources"
     name: "smart_stopwords_2.txt"
     version: 1
   }
-
 }
 
-org.allenai.common.indexing.base: {
-  elasticSearch: {
+org.allenai.common.indexing.base {
+  elasticSearch {
     // Specify the right clustername. It usually defaults to `elasticsearch` but
     // you can verify by using the command:
     // curl -XGET 'http://localhost:9200/_cluster/health?pretty=true'.
-    // For Aristo Solvers, the hostIp should be changed to `aristo-es1.dev.ai2`
+    // For Aristo Solvers, the hostIp should be changed to `aristo-es.dev.ai2`
     // with clusterName `aristo-es`.
     clusterName: "elasticsearch"
     hostIp: "127.0.0.1"
@@ -21,30 +21,21 @@ org.allenai.common.indexing.base: {
     indexName: "lucene"
   }
 
-  buildIndexOptions: {
+  buildIndexOptions {
     buildFromScratch: true
     dumpFolder: "common/src/main/resources/org/allenai/ari/indexing/dump"
   }
 }
 
 org.allenai.common.indexing.sentence_base: ${org.allenai.common.indexing.base} {
-  elasticSearch: {
+  elasticSearch {
     indexType: "sentence"
-    mapping: {
-      sentence: {
+    mapping {
+      sentence {
         dynamic: false,
-        properties: {
-          text: {
-            type: "multi_field",
-            fields: {
-              text: {type: "string", analyzer: "snowball"}
-              text_raw: {type: "string", index: "not_analyzed"},
-            }
-          }
-          source: {
-            type: "string",
-            index: "not_analyzed"
-          }
+        properties {
+          text = ${stemmedTextField}
+          source = ${rawTextField}
         }
       }
     }
@@ -52,23 +43,14 @@ org.allenai.common.indexing.sentence_base: ${org.allenai.common.indexing.base} {
 }
 
 org.allenai.common.indexing.paragraph_base: ${org.allenai.common.indexing.base} {
-  elasticSearch: {
+  elasticSearch {
     indexType: "paragraph"
-    mapping: {
-      paragraph: {
+    mapping {
+      paragraph {
         dynamic: false,
-        properties: {
-          text: {
-            type: "multi_field",
-            fields: {
-              text: {type: "string", analyzer: "snowball"}
-              text_raw: {type: "string", index: "not_analyzed"},
-            }
-          }
-          source: {
-            type: "string",
-            index: "not_analyzed"
-          }
+        properties {
+          text = ${stemmedTextField}
+          source = ${rawTextField}
         }
       }
     }
@@ -76,30 +58,15 @@ org.allenai.common.indexing.paragraph_base: ${org.allenai.common.indexing.base} 
 }
 
 org.allenai.common.indexing.qa_base: ${org.allenai.common.indexing.base} {
-  elasticSearch: {
+  elasticSearch {
     indexType: "question-answer"
-    mapping: {
-      question-answer: {
+    mapping {
+      question-answer {
         dynamic: false,
-        properties: {
-          question: {
-            type: "string",
-            analyzer: "snowball", 
-            fields: {
-              raw: {type: "string", index: "not_analyzed"}
-            }
-          }
-          answer: {
-            type: "string",
-            analyzer: "snowball",
-            fields: {
-              raw: {type: "string", index: "not_analyzed"}
-            }
-          }
-          source: {
-            type: "string",
-            index: "not_analyzed"
-          }
+        properties {
+          question = ${stemmedTextField}
+          answer = ${stemmedTextField}
+          source = ${rawTextField}
         }
       }
     }
@@ -107,30 +74,15 @@ org.allenai.common.indexing.qa_base: ${org.allenai.common.indexing.base} {
 }
 
 org.allenai.common.indexing.termdef_base: ${org.allenai.common.indexing.base} {
-  elasticSearch: {
+  elasticSearch {
     indexType: "term-definition"
-    mapping: {
-      term-definition: {
+    mapping {
+      term-definition {
         dynamic: false,
-        properties: {
-          term: {
-            type: "string",
-            analyzer: "snowball",
-            fields: {
-              raw: {type: "string", index: "not_analyzed"}
-            }
-          }
-          definition: {
-            type: "string",
-            analyzer: "snowball",
-            fields: {
-              raw: {type: "string", index: "not_analyzed"}
-            }
-          }
-          source: {
-            type: "string",
-            index: "not_analyzed"
-          }
+        properties {
+          term = ${stemmedTextField}
+          definition = ${stemmedTextField}
+          source = ${rawTextField}
         }
       }
     }
@@ -309,4 +261,3 @@ org.allenai.common.indexing.studystack_termdef: ${org.allenai.common.indexing.te
     }
   ]
 }
-

--- a/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/indexing.conf
@@ -9,14 +9,13 @@ org.allenai.common.indexing.stoplist {
 org.allenai.common.indexing.base {
   elasticSearch {
     hostAddress: "127.0.0.1"
-    hostPort: 9300
 
     // Your cluster name can be obtained with the following command.
     // curl -XGET 'http://<hostAddress>:9200/_cluster/health?pretty=true'.
     clusterName: "elasticsearch"
     indexName: "lucene"
 
-    // Aristo should override the following values:
+    // Aristo should override the above values with the following:
     //clusterName: "aristo-es"
     //hostAddress: "aristo-es.dev.ai2"
   }

--- a/indexing/src/main/resources/org/allenai/common/indexing/mappingHelpers.conf
+++ b/indexing/src/main/resources/org/allenai/common/indexing/mappingHelpers.conf
@@ -1,0 +1,14 @@
+// Format of all raw (non-analyzed) text fields:
+rawTextField {
+  type = "string"
+  index = "not_analyzed"
+}
+
+// Format of all stemmed text fields, including a raw interpretation:
+stemmedTextField {
+  type = "string"
+  analyzer = "snowball"
+  fields {
+    raw = ${rawTextField}
+  }
+}

--- a/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/BuildCorpusIndex.scala
@@ -23,6 +23,8 @@ import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success }
 import java.io.File
 import java.nio.file.{ Files, Path, Paths }
+import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.concurrent.TimeUnit
 
 /** CLI to build an Elastic Search index on Aristo corpora.
@@ -36,7 +38,13 @@ class BuildCorpusIndex(config: Config) extends Logging {
 
   /** Get Index Name and Index Type. */
   val esConfig: Config = config[Config]("elasticSearch")
-  val indexName: String = esConfig[String]("indexName")
+  val indexName: String = {
+    // The index name must be appended with the current date.
+    val name = esConfig[String]("indexName")
+    val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
+    name + "-" + dateFormat.format(Calendar.getInstance().getTime())
+  }
+
   val indexType: String = esConfig[String]("indexType")
 
   val buildFromScratch = config.get[Boolean]("buildIndexOptions.buildFromScratch").getOrElse(true)

--- a/indexing/src/main/scala/org/allenai/common/indexing/ElasticSearchTransportClientUtil.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/ElasticSearchTransportClientUtil.scala
@@ -31,7 +31,7 @@ object ElasticSearchTransportClientUtil extends Logging {
       .put("sniffOnConnectionFault", sniffMode)
       .build()
     val address = new InetSocketTransportAddress(
-      new InetSocketAddress(esConfig.getString("hostIp"), esConfig.getInt("hostPort"))
+      new InetSocketAddress(esConfig.getString("hostAddress"), esConfig.getInt("hostPort"))
     )
 
     logger.debug(s"Created Elastic Search Client in cluster ${esConfig.getString("clusterName")}")

--- a/indexing/src/main/scala/org/allenai/common/indexing/ElasticSearchTransportClientUtil.scala
+++ b/indexing/src/main/scala/org/allenai/common/indexing/ElasticSearchTransportClientUtil.scala
@@ -30,9 +30,8 @@ object ElasticSearchTransportClientUtil extends Logging {
       .put("client.transport.sniff", sniffMode)
       .put("sniffOnConnectionFault", sniffMode)
       .build()
-    val address = new InetSocketTransportAddress(
-      new InetSocketAddress(esConfig.getString("hostAddress"), esConfig.getInt("hostPort"))
-    )
+    val host = esConfig.getString("hostAddress")
+    val address = new InetSocketTransportAddress(new InetSocketAddress(host, 9300))
 
     logger.debug(s"Created Elastic Search Client in cluster ${esConfig.getString("clusterName")}")
     val clientBuilder = TransportClient.builder().settings(settings)


### PR DESCRIPTION
This change reduces copy-paste index mappings in `indexing.conf` and adds a date tag to index names to allow for reindexing an existing corpus.