### PR TITLE
update BingClient to bing v5 api

### DIFF
--- a/webapp/src/main/scala/org/allenai/common/webapp/BingClient.scala
+++ b/webapp/src/main/scala/org/allenai/common/webapp/BingClient.scala
@@ -62,7 +62,7 @@ class BingClient(apiKey: String) {
     val filter = if (responseFilter.isEmpty) "" else s"&responseFilter=${responseFilter}"
 
     val uri = s"https://api.cognitive.microsoft.com/bing/v5.0/" +
-        s"search?q=${encodedQuery}&count=${top}${filter}"
+      s"search?q=${encodedQuery}&count=${top}${filter}"
 
     val request = new Request.Builder()
       .url(uri)

--- a/webapp/src/main/scala/org/allenai/common/webapp/BingClient.scala
+++ b/webapp/src/main/scala/org/allenai/common/webapp/BingClient.scala
@@ -61,7 +61,8 @@ class BingClient(apiKey: String) {
     val encodedQuery = "%27" + URLEncoder.encode(query, "UTF-8") + "%27"
     val filter = if (responseFilter.isEmpty) "" else s"&responseFilter=${responseFilter}"
 
-    val uri = s"https://api.cognitive.microsoft.com/bing/v5.0/search?q=${encodedQuery}${filter}"
+    val uri = s"https://api.cognitive.microsoft.com/bing/v5.0/" +
+        s"search?q=${encodedQuery}&count=${top}${filter}"
 
     val request = new Request.Builder()
       .url(uri)

--- a/webapp/src/test/scala/org/allenai/common/webapp/BingClientSpec.scala
+++ b/webapp/src/test/scala/org/allenai/common/webapp/BingClientSpec.scala
@@ -6,7 +6,19 @@ import java.util.NoSuchElementException
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Failure, Success }
 
+import java.net.URISyntaxException
+
 class BingClientSpec extends UnitSpec {
+  // Not perfect, I got it from http://stackoverflow.com/a/20039133/1076346
+  def isValidUri(maybeUri: String): Boolean = {
+    try {
+      val uri = new java.net.URI(maybeUri)
+      uri.getHost() != null
+    } catch {
+      case e: URISyntaxException => false
+    }
+  }
+
   // If the Azure auth key isn't defined, just skip these tests.
   val apiKey = try {
     Some(sys.env("AZURE_AUTH_KEY"))
@@ -20,6 +32,7 @@ class BingClientSpec extends UnitSpec {
     if (bingClient.isDefined) {
       val results = bingClient.get.query("aardvark")
       assert(results.nonEmpty)
+      assert(results.map(_.url).forall(isValidUri))
     } else {
       cancel("AZURE_AUTH_KEY not defined, skipping test")
     }


### PR DESCRIPTION
main changes:

* update url to api.cognitive.microsoft.com
* source type becomes response filter (I don't think anyone was explicitly setting this)
* various other query changes
* results now at `json["webPages"]["value"]`
* ID -> id (I don't think it's exactly the same field either, I think the old one is deprecated)
* Url -> url, and is a bing redirect we need to get the actual url out of
* Title -> name
* Description -> snippet

see https://msdn.microsoft.com/en-US/library/mt707570.aspx#web for details

you also need a new v5 subscription key to use this, you can get it from techops, it's called aristo-bing-client