### PR TITLE
Fix keys containing dots.

### DIFF
--- a/guice/src/main/scala/org/allenai/common/guice/ConfigModule.scala
+++ b/guice/src/main/scala/org/allenai/common/guice/ConfigModule.scala
@@ -156,7 +156,7 @@ class ConfigModule(config: Config) extends ScalaModule with Logging {
         case ConfigValueType.OBJECT =>
           bindConfigKey[Config](fullPath)
           // Recurse.
-          bindConfigObject(config.toConfig()[Config](key).root, fullPathElements)
+          bindConfigObject(config.toConfig()[Config](ConfigUtil.quoteString(key)).root, fullPathElements)
         case other =>
           // Shouldn't happen - but warn if it does.
           logger.warn(s"Unhandled config value type [$other] for key $key")


### PR DESCRIPTION
Fixes #213 .

I ran into this prototyping some Guice stuff for `scholar/online/service`.

The code is really simple; hopefully the unit tests make it clear what's happening.