### PR TITLE
Update plugin

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies extends CoreDependencies {
 
   val mockJedis = "com.fiftyonred" % "mock-jedis" % "0.4.0"
 
-  def nlpstack(component: String) = ("org.allenai.nlpstack" % s"nlpstack-${component}_2.11" % "1.6")
+  def nlpstack(component: String) = ("org.allenai.nlpstack" %% s"nlpstack-${component}" % "1.6")
     .exclude("commons-logging", "commons-logging")
 
   val okHttp = "com.squareup.okhttp3" % "okhttp" % "3.4.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "1.2.1")
+addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "1.5.0")


### PR DESCRIPTION
Semaphore build tasks are currently timing out due to a reference to our old nexus repository in the old sbt plugin version we're using.

This fixes that, and another issue with a badly-declared dependency.