### PR TITLE
Restore serialization when a constructor argument exists.

### DIFF
--- a/core/src/main/scala/org/allenai/common/Enum.scala
+++ b/core/src/main/scala/org/allenai/common/Enum.scala
@@ -3,7 +3,7 @@ package org.allenai.common
 import spray.json.{ deserializationError, JsString, JsValue, RootJsonFormat }
 
 /** Enumeration implementation that supports automatic Spray JSON serialization of a case object as
-  * a JsString.
+  * a JsString, or using java native serialization for Spark jobs.
   *
   * Usage:
   * (format: OFF)
@@ -23,7 +23,7 @@ import spray.json.{ deserializationError, JsString, JsValue, RootJsonFormat }
   * }}}
   * (format: ON)
   */
-abstract class Enum[E <: Enum[E]] {
+abstract class Enum[E <: Enum[E]] extends Serializable {
   /** The serialization string. By default, use the toString implementation. For a case object, this
     * uses the object name.
     */

--- a/core/src/test/scala/org/allenai/common/EnumSpec.scala
+++ b/core/src/test/scala/org/allenai/common/EnumSpec.scala
@@ -40,6 +40,22 @@ class EnumSpec extends UnitSpec {
     }
   }
 
+  "Java serialization" should "work with no constructor argument" in {
+    FakeEnum.all foreach { enum =>
+      val tmp = Files.createTempFile(enum.id, "dat")
+      val tmpFile = tmp.toFile()
+      tmpFile.deleteOnExit()
+      Resource.using(new ObjectOutputStream(new FileOutputStream(tmpFile))) { os =>
+        os.writeObject(enum)
+      }
+      val obj = Resource.using(new ObjectInputStream(new FileInputStream(tmpFile))) { is =>
+        is.readObject()
+      }
+      obj should equal(enum)
+      tmpFile.delete()
+    }
+  }
+
   it should "work with a constructor argument" in {
     FakeEnumWithId.all foreach { enum =>
       val tmp = Files.createTempFile(enum.id, "dat")

--- a/core/src/test/scala/org/allenai/common/EnumSpec.scala
+++ b/core/src/test/scala/org/allenai/common/EnumSpec.scala
@@ -40,8 +40,8 @@ class EnumSpec extends UnitSpec {
     }
   }
 
-  "Java serialization" should "work" in {
-    FakeEnum.all foreach { enum =>
+  it should "work with a constructor argument" in {
+    FakeEnumWithId.all foreach { enum =>
       val tmp = Files.createTempFile(enum.id, "dat")
       val tmpFile = tmp.toFile()
       tmpFile.deleteOnExit()
@@ -64,5 +64,15 @@ object FakeEnum extends EnumCompanion[FakeEnum] {
   case object Value1 extends FakeEnum
   case object Value2 extends FakeEnum
   case object Value3 extends FakeEnum
+  register(Value1, Value2, Value3)
+}
+
+// Test enum. Must be defined outside of spec otherwise serialization tests will
+// fail due to scalatest WordSpec not being serializable.
+sealed abstract class FakeEnumWithId(override val id: String) extends Enum[FakeEnumWithId]
+object FakeEnumWithId extends EnumCompanion[FakeEnumWithId] {
+  case object Value1 extends FakeEnumWithId("one")
+  case object Value2 extends FakeEnumWithId("two")
+  case object Value3 extends FakeEnumWithId("three")
   register(Value1, Value2, Value3)
 }


### PR DESCRIPTION
Add a unit test to cover this case.

This fixes a backwards-compatibility issue - I'm restoring a feature I broke.