### PR TITLE
Adding default CORS header to allow all HTTP methods

### DIFF
--- a/webapp/src/main/scala/org/allenai/common/webapp/Directives.scala
+++ b/webapp/src/main/scala/org/allenai/common/webapp/Directives.scala
@@ -25,6 +25,7 @@ trait Directives {
       } map { goodOrigin =>
         respondWithHeaders(
           Headers.AccessControlAllowHeadersAll,
+          Headers.AccessControlAllowMethodsCommon,
           HttpHeaders.`Access-Control-Allow-Origin`(SomeOrigins(Seq(goodOrigin)))
         ) {
             options {

--- a/webapp/src/main/scala/org/allenai/common/webapp/Directives.scala
+++ b/webapp/src/main/scala/org/allenai/common/webapp/Directives.scala
@@ -25,7 +25,7 @@ trait Directives {
       } map { goodOrigin =>
         respondWithHeaders(
           Headers.AccessControlAllowHeadersAll,
-          Headers.AccessControlAllowMethodsCommon,
+          Headers.AccessControlAllowMethodsAll,
           HttpHeaders.`Access-Control-Allow-Origin`(SomeOrigins(Seq(goodOrigin)))
         ) {
             options {

--- a/webapp/src/main/scala/org/allenai/common/webapp/Headers.scala
+++ b/webapp/src/main/scala/org/allenai/common/webapp/Headers.scala
@@ -1,6 +1,6 @@
 package org.allenai.common.webapp
 
-import spray.http.{HttpHeaders, HttpMethods}
+import spray.http.{ HttpHeaders, HttpMethods }
 
 /** Helpers for setting HTTP headers. */
 object Headers {
@@ -8,7 +8,17 @@ object Headers {
   val AccessControlAllowHeadersAll = HttpHeaders.`Access-Control-Allow-Headers`(
     Seq("Origin", "X-Requested-With", "Content-Type", "Accept")
   )
-  val AccessControlAllowMethodsCommon = HttpHeaders.`Access-Control-Allow-Methods`(
-    Seq(HttpMethods.GET, HttpMethods.POST, HttpMethods.PUT, HttpMethods.DELETE)
+  val AccessControlAllowMethodsAll = HttpHeaders.`Access-Control-Allow-Methods`(
+    Seq(
+      HttpMethods.CONNECT,
+      HttpMethods.DELETE,
+      HttpMethods.GET,
+      HttpMethods.HEAD,
+      HttpMethods.OPTIONS,
+      HttpMethods.PATCH,
+      HttpMethods.POST,
+      HttpMethods.PUT,
+      HttpMethods.TRACE
+    )
   )
 }

--- a/webapp/src/main/scala/org/allenai/common/webapp/Headers.scala
+++ b/webapp/src/main/scala/org/allenai/common/webapp/Headers.scala
@@ -1,11 +1,14 @@
 package org.allenai.common.webapp
 
-import spray.http.HttpHeaders
+import spray.http.{HttpHeaders, HttpMethods}
 
 /** Helpers for setting HTTP headers. */
 object Headers {
   /** Allows any reasonable header to be sent cross-site. */
   val AccessControlAllowHeadersAll = HttpHeaders.`Access-Control-Allow-Headers`(
     Seq("Origin", "X-Requested-With", "Content-Type", "Accept")
+  )
+  val AccessControlAllowMethodsCommon = HttpHeaders.`Access-Control-Allow-Methods`(
+    Seq(HttpMethods.GET, HttpMethods.POST, HttpMethods.PUT, HttpMethods.DELETE)
   )
 }


### PR DESCRIPTION
Our current implementation only allows the default GET and POST verbs. This should add support for the rest of them.