### PR TITLE
bring back version and test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,13 @@ lazy val projectSettings = Seq(
 
 lazy val buildSettings = Seq(
   javaOptions += s"-Dlogback.appname=${name.value}",
-  scalacOptions ++= Seq("-target:jvm-1.8", "-Xlint", "-deprecation", "-feature"),
+  scalacOptions ++= Seq(
+    "-target:jvm-1.8",
+    "-Xlint",
+    "-deprecation",
+    "-feature",
+    "-Xfatal-warnings"
+  ),
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   crossScalaVersions := supportedScalaVersions
 )

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,15 @@ lazy val buildSettings = Seq(
     "-Xfatal-warnings"
   ),
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-  crossScalaVersions := supportedScalaVersions
+  crossScalaVersions := supportedScalaVersions,
+  unmanagedSourceDirectories.in(Compile) ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, x)) if x == 11 || x == 12 =>
+        Seq(file(sourceDirectory.value.getPath + "/main/scala-2.11-2.12"))
+      case Some((2, x)) if x == 13 => Seq(file(sourceDirectory.value.getPath + "/main/scala-2.13"))
+      case _ => Seq.empty // dotty support would go here
+    }
+  }
 )
 
 // Not necessary for this repository but here as an example

--- a/core/src/main/scala-2.11-2.12/org/allenai/common/Compat.scala
+++ b/core/src/main/scala-2.11-2.12/org/allenai/common/Compat.scala
@@ -1,0 +1,14 @@
+package org.allenai.common
+
+import scala.collection.convert._
+
+object Compat {
+  object JavaConverters extends DecorateAsJava with DecorateAsScala
+
+  object IterableOps {
+    implicit class IterableOpsImplicits[A](iter: Iterable[A]) {
+      def toStreamCompat: Stream[A] = iter.toStream
+      def toIteratorCompat: Iterator[A] = iter.toIterator
+    }
+  }
+}

--- a/core/src/main/scala-2.13/org/allenai/common/Compat.scala
+++ b/core/src/main/scala-2.13/org/allenai/common/Compat.scala
@@ -1,0 +1,14 @@
+package org.allenai.common
+
+import scala.collection.convert._
+
+object Compat {
+  object JavaConverters extends AsJavaExtensions with AsScalaExtensions
+
+  object IterableOps {
+    implicit class IterableOpsImplicits[A](iter: Iterable[A]) {
+      def toStreamCompat: LazyList[A] = iter.to(LazyList)
+      def toIteratorCompat: Iterator[A] = iter.iterator
+    }
+  }
+}

--- a/core/src/main/scala/org/allenai/common/Config.scala
+++ b/core/src/main/scala/org/allenai/common/Config.scala
@@ -1,10 +1,10 @@
 package org.allenai.common
 
+import Compat.JavaConverters._
 import com.typesafe.config.{ Config => TypesafeConfig, _ }
 import spray.json._
 
 import java.net.URI
-import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 /** Import to provide enhancements via implicit class conversion for making working

--- a/core/src/main/scala/org/allenai/common/FileUtils.scala
+++ b/core/src/main/scala/org/allenai/common/FileUtils.scala
@@ -1,10 +1,9 @@
 package org.allenai.common
 
 import au.com.bytecode.opencsv.CSVReader
+import Compat.JavaConverters._
 
 import java.io.{ BufferedInputStream, BufferedReader, File, FileInputStream, InputStreamReader }
-
-import scala.collection.JavaConverters._
 import scala.io.{ BufferedSource, Codec, Source }
 
 /** Various convenient utilities for reading files and resources. */

--- a/core/src/main/scala/org/allenai/common/JsonIo.scala
+++ b/core/src/main/scala/org/allenai/common/JsonIo.scala
@@ -2,9 +2,8 @@ package org.allenai.common
 
 import spray.json._
 
-import scala.io.Source
-
 import java.io.{ OutputStream, PrintWriter, Writer }
+import scala.io.Source
 
 /** Helpers for streaming lists of JSON objects to and from disk. */
 object JsonIo {
@@ -12,8 +11,8 @@ object JsonIo {
   /** Reads single-lines from a given Source, and streams the JSON parsed from them to the caller.
     * @return a stream of objects of type T
     */
-  def parseJson[T](source: Source)(implicit format: JsonFormat[T]): Stream[T] = {
-    for (line <- source.getLines().toStream) yield line.parseJson.convertTo[T]
+  def parseJson[T](source: Source)(implicit format: JsonFormat[T]): Iterator[T] = {
+    for (line <- source.getLines) yield line.parseJson.convertTo[T]
   }
 
   /** Writes the given objects to the given writer, as one-per-line JSON values. */

--- a/core/src/main/scala/org/allenai/common/ParIterator.scala
+++ b/core/src/main/scala/org/allenai/common/ParIterator.scala
@@ -94,7 +94,7 @@ object ParIterator {
       f: T => O,
       queueLimit: Int = defaultQueueLimit
     )(implicit ec: ExecutionContext): Iterator[O] = new Iterator[O] {
-      private val inner = input.toIterator
+      private val inner = input
       private val q = new scala.collection.mutable.Queue[Future[O]]()
 
       private def fillQueue(): Unit = {

--- a/core/src/main/scala/org/allenai/common/Version.scala
+++ b/core/src/main/scala/org/allenai/common/Version.scala
@@ -1,0 +1,144 @@
+package org.allenai.common
+
+import org.allenai.common.Config._
+import org.allenai.common.json._
+
+import com.typesafe.config.ConfigFactory
+import spray.json.{ JsNumber, JsObject, JsString, JsValue, RootJsonFormat }
+
+import scala.collection.JavaConverters._
+
+import java.util.Date
+
+/** Represents a git version.
+  * @param sha1 the output of `git sha1` in the repository
+  * @param commitDate commit date in milliseconds
+  * @param repoUrl the url of the git repo
+  */
+case class GitVersion(sha1: String, commitDate: Long, repoUrl: Option[String]) {
+
+  /** A URL pointing to the specific commit on GitHub. */
+  def commitUrl: Option[String] = {
+    repoUrl.map { base =>
+      base + "/commit/" + sha1
+    }
+  }
+
+  /** @return a formatted date string */
+  def prettyCommitDate: String = {
+    String.format("%1$tF %1$tT GMT%1$tz", new Date(commitDate))
+  }
+}
+
+object GitVersion {
+  import spray.json.DefaultJsonProtocol._
+  implicit val gitVersionFormat = jsonFormat3(GitVersion.apply)
+
+  /** The GitHub project URL.
+    *
+    * The remotes are searched for one with user "allenai" and then it's transformed into a valid
+    * GitHub project URL.
+    * @return a URL to a GitHub repo, or None if no allenai remotes exist
+    */
+  def projectUrl(remotes: Seq[String], user: String): Option[String] = {
+    val sshRegex = """git@github.com:([\w-]+)/([\w-]+).git""".r
+    val httpsRegex = """https://github.com/([\w-]+)/([\w-]+).git""".r
+
+    remotes.collect {
+      case sshRegex(u, repo) if u == user => s"http://github.com/$user/$repo"
+      case httpsRegex(u, repo) if u == user => s"http://github.com/$user/$repo"
+    }.headOption
+  }
+
+  def create(sha1: String, commitDate: Long, remotes: Seq[String]) = {
+    GitVersion(sha1, commitDate, projectUrl(remotes, "allenai"))
+  }
+}
+
+/** Represents the version of this component. Should be built with the `fromResources` method on the
+  * companion object.
+  * @param git the git version (commit information) of the build.
+  * @param artifactVersion the version of the artifact in the build.
+  * @param cacheKey a cacheKey of the project. Changes on git commits to src of project and
+  * dependency changes.
+  */
+case class Version(
+  git: GitVersion,
+  artifactVersion: String,
+  cacheKey: Option[String]
+) {
+  @deprecated("Use artifactVersion instead.", "2014.09.09-1-SNAPSHOT")
+  def artifact = artifactVersion
+}
+
+object Version {
+
+  /** Load a Version instance from the resources injected by the
+    * [[https://git.io/vzdZl Version injector sbt plugin]].
+    * This attempts to load using [[Version]]'s class loader.
+    * @param org the value of the sbt key `organization` to find
+    * @param name the value of the sbt key `name` to find
+    */
+  def fromResources(org: String, name: String): Version = {
+    fromResources(org, name, this.getClass.getClassLoader)
+  }
+
+  /** Load a Version instance from the resources injected by the
+    * [[https://git.io/vzdZl Version injector sbt plugin]].
+    * This attempts to load using the given class loader.
+    * @param org the value of the sbt key `organization` to find
+    * @param name the value of the sbt key `name` to find
+    * @param classLoader the class loader to use
+    */
+  def fromResources(org: String, name: String, classLoader: ClassLoader): Version = {
+    val prefix = s"$org/${name.replaceAll("-", "")}"
+
+    val artifactConfPath = s"$prefix/artifact.conf"
+    val gitConfPath = s"$prefix/git.conf"
+
+    val artifactConfUrl = classLoader.getResource(artifactConfPath)
+    val gitConfUrl = classLoader.getResource(gitConfPath)
+
+    require(artifactConfUrl != null, s"Could not find $artifactConfPath")
+    require(gitConfUrl != null, s"Could not find $gitConfPath")
+
+    val artifactConf = ConfigFactory.parseURL(artifactConfUrl)
+    val gitConf = ConfigFactory.parseURL(gitConfUrl)
+    val artifactVersion = artifactConf[String]("version")
+    val sha1 = gitConf[String]("sha1")
+    val commitDate = gitConf[Long]("date")
+    val remotes = gitConf.getStringList("remotes").asScala
+    val cacheKey = Option(System.getProperty("application.cacheKey"))
+    Version(GitVersion.create(sha1, commitDate, remotes), artifactVersion, cacheKey)
+  }
+
+  /** Custom JSON serialization for backwards-compatibility. */
+  implicit val versionJsonFormat = new RootJsonFormat[Version] {
+    import spray.json.DefaultJsonProtocol._
+    override def write(version: Version): JsValue = {
+      val baseJson = JsObject(
+        "git" -> JsString(version.git.sha1),
+        "commitDate" -> JsNumber(version.git.commitDate),
+        "artifact" -> JsString(version.artifactVersion)
+      )
+      version.git.repoUrl match {
+        case Some(repoUrl) => baseJson.pack("repoUrl" -> repoUrl)
+        case _ => baseJson
+      }
+      version.cacheKey match {
+        case Some(cacheKey) => baseJson.pack("cacheKey" -> cacheKey)
+        case _ => baseJson
+      }
+    }
+
+    override def read(json: JsValue): Version = {
+      val jsObject = json.asJsObject
+      val gitSha1 = jsObject.apply[String]("git")
+      val commitDate = jsObject.apply[Long]("commitDate")
+      val artifactVersion = jsObject.apply[String]("artifact")
+      val repoUrl = jsObject.get[String]("repoUrl")
+      val cacheKey = jsObject.get[String]("cacheKey")
+      Version(GitVersion(gitSha1, commitDate, repoUrl), artifactVersion, cacheKey)
+    }
+  }
+}

--- a/core/src/main/scala/org/allenai/common/Version.scala
+++ b/core/src/main/scala/org/allenai/common/Version.scala
@@ -1,12 +1,11 @@
 package org.allenai.common
 
+import Compat.JavaConverters._
 import org.allenai.common.Config._
 import org.allenai.common.json._
 
 import com.typesafe.config.ConfigFactory
 import spray.json.{ JsNumber, JsObject, JsString, JsValue, RootJsonFormat }
-
-import scala.collection.JavaConverters._
 
 import java.util.Date
 
@@ -107,7 +106,7 @@ object Version {
     val artifactVersion = artifactConf[String]("version")
     val sha1 = gitConf[String]("sha1")
     val commitDate = gitConf[Long]("date")
-    val remotes = gitConf.getStringList("remotes").asScala
+    val remotes = gitConf.getStringList("remotes").asScala.toSeq
     val cacheKey = Option(System.getProperty("application.cacheKey"))
     Version(GitVersion.create(sha1, commitDate, remotes), artifactVersion, cacheKey)
   }

--- a/core/src/test/scala/org/allenai/common/ConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/ConfigSpec.scala
@@ -1,5 +1,6 @@
 package org.allenai.common
 
+import Compat.JavaConverters._
 import org.allenai.common.testkit.UnitSpec
 import org.allenai.common.Config._
 
@@ -7,7 +8,6 @@ import com.typesafe.config.{ Config => TypesafeConfig, _ }
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
-import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 import java.net.URI

--- a/core/src/test/scala/org/allenai/common/JsonIoSpec.scala
+++ b/core/src/test/scala/org/allenai/common/JsonIoSpec.scala
@@ -2,10 +2,9 @@ package org.allenai.common
 
 import org.allenai.common.testkit.UnitSpec
 
-import spray.json._
 import spray.json.DefaultJsonProtocol._
 
-import scala.io.{ Codec, Source }
+import scala.io.Source
 
 import java.io.ByteArrayOutputStream
 

--- a/core/src/test/scala/org/allenai/common/JsonIoSpec.scala
+++ b/core/src/test/scala/org/allenai/common/JsonIoSpec.scala
@@ -34,18 +34,18 @@ class JsonIoSpec extends UnitSpec {
 
   "parseJson and writeJson" should "pipe correctly to each other" in {
     // Input. We'll pipe through writeJson & toJson twice (testing both directions).
-    val input = Seq(Foo("a"), Foo("b"), Foo("c"), Foo("d"))
+    val input = List(Foo("a"), Foo("b"), Foo("c"), Foo("d"))
 
     // Intermediary: Test that write -> read works.
     val buffer = new ByteArrayOutputStream()
     JsonIo.writeJson(input, buffer)
     val intermediaryOutput = JsonIo.parseJson[Foo](Source.fromString(buffer.toString("UTF8")))
-    intermediaryOutput should be(input)
+    intermediaryOutput.toList should be(input)
 
     // Final: Test that read -> write works (with a bonus read).
     buffer.reset()
     JsonIo.writeJson(input, buffer)
     val finalOutput = JsonIo.parseJson[Foo](Source.fromString(buffer.toString("UTF8")))
-    finalOutput should be(input)
+    finalOutput.toList should be(input)
   }
 }

--- a/core/src/test/scala/org/allenai/common/ParIteratorSpec.scala
+++ b/core/src/test/scala/org/allenai/common/ParIteratorSpec.scala
@@ -1,15 +1,15 @@
 package org.allenai.common
 
-import java.util.concurrent.ConcurrentSkipListSet
-import java.util.concurrent.atomic.AtomicInteger
-
+import Compat.JavaConverters._
+import Compat.IterableOps.IterableOpsImplicits
 import org.allenai.common.testkit.UnitSpec
 import org.allenai.common.ParIterator.ParIteratorEnrichment
 
+import java.util.concurrent.ConcurrentSkipListSet
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
-import scala.collection.JavaConverters._
 
 class ParIteratorSpec extends UnitSpec {
   // With small values (<1000) for scale, this test is unreliable, and with large ones it takes
@@ -36,31 +36,31 @@ class ParIteratorSpec extends UnitSpec {
       val successes = new ConcurrentSkipListSet[Int]()
 
       val max = 2000
-      val iter = Range(0, max).toIterator
+      val iter = Range(0, max).toIteratorCompat
       iter.parForeach { i =>
         Thread.sleep((max - i) % 10)
         successes.add(i)
       }
       val expected = Range(0, max).toSet
 
-      assert((successes.asScala -- expected) === Set.empty)
-      assert((expected -- successes.asScala) === Set.empty)
+      assert((successes.asScala.toSet -- expected) === Set.empty)
+      assert((expected -- successes.asScala.toSet) === Set.empty)
 
       Thread.sleep(1000)
 
-      assert((successes.asScala -- expected) === Set.empty)
-      assert((expected -- successes.asScala) === Set.empty)
+      assert((successes.asScala.toSet -- expected) === Set.empty)
+      assert((expected -- successes.asScala.toSet) === Set.empty)
     }
   }
 
   it should "nest properly" in {
     val count = new AtomicInteger()
     val max = 13
-    Range(0, max).toIterator.parForeach { _ =>
-      Range(0, max).toIterator.parForeach { _ =>
+    Range(0, max).toIteratorCompat.parForeach { _ =>
+      Range(0, max).toIteratorCompat.parForeach { _ =>
         val successes = new ConcurrentSkipListSet[Int]()
 
-        val iter = Range(0, max).toIterator
+        val iter = Range(0, max).toIteratorCompat
         iter.parForeach { i =>
           Thread.sleep((i * max * max) % 10)
           successes.add(i)
@@ -68,8 +68,8 @@ class ParIteratorSpec extends UnitSpec {
         }
         val expected = Range(0, max).toSet
 
-        assert((successes.asScala -- expected) === Set.empty)
-        assert((expected -- successes.asScala) === Set.empty)
+        assert((successes.asScala.toSet -- expected) === Set.empty)
+        assert((expected -- successes.asScala.toSet) === Set.empty)
       }
     }
 
@@ -79,7 +79,7 @@ class ParIteratorSpec extends UnitSpec {
   it should "map things concurrently" in {
     val max = 5
     val values = Range(0, max).reverse
-    val iter = values.toIterator
+    val iter = values.toIteratorCompat
     val expected = values.map { i =>
       s"$i"
     }
@@ -98,7 +98,7 @@ class ParIteratorSpec extends UnitSpec {
   it should "map lots of things concurrently" in {
     val max = 50000
     val values = Range(0, max).reverse
-    val iter = values.toIterator
+    val iter = values.toIteratorCompat
     val expected = values.map { i =>
       s"$i"
     }
@@ -111,7 +111,7 @@ class ParIteratorSpec extends UnitSpec {
   it should "return exceptions from foreach functions" in {
     val successes = synchronized(collection.mutable.Set[Int]())
     intercept[ArithmeticException] {
-      Range(-20, 20).toIterator.parForeach { i =>
+      Range(-20, 20).toIteratorCompat.parForeach { i =>
         successes.add(10000 / i)
       }
     }
@@ -129,7 +129,7 @@ class ParIteratorSpec extends UnitSpec {
 
   it should "return exceptions from map" in {
     intercept[ArithmeticException] {
-      Range(-20, 20).toIterator.parMap(10000 / _).toList
+      Range(-20, 20).toIteratorCompat.parMap(10000 / _).toList
     }
   }
 }

--- a/core/src/test/scala/org/allenai/common/VersionSpec.scala
+++ b/core/src/test/scala/org/allenai/common/VersionSpec.scala
@@ -1,0 +1,79 @@
+package org.allenai.common
+
+import org.allenai.common.testkit.UnitSpec
+
+import spray.json._
+
+import java.net.URLClassLoader
+import java.nio.file.Paths
+
+class GitVersionSpec extends UnitSpec {
+  "create" should "find the correct GitHub project URL (ssh)" in {
+    val version = GitVersion.create(
+      "gitSha",
+      1234,
+      Seq(
+        "https://github.com/schmmd/parsers.git",
+        "git@github.com:allenai/common.git"
+      )
+    )
+    version.repoUrl shouldBe Some("http://github.com/allenai/common")
+  }
+
+  it should "find the correct GitHub project URL (https)" in {
+    val version = GitVersion.create(
+      "gitSha",
+      1234,
+      Seq(
+        "https://github.com/allenai/ari-datastore.git",
+        "git@github.com:schmmd/common.git"
+      )
+    )
+    version.repoUrl shouldBe Some("http://github.com/allenai/ari-datastore")
+  }
+
+  it should "find the correct GitHub commit URL" in {
+    val version = GitVersion.create(
+      "e0d972e185bd12b94dedd38834fea150a68f064e",
+      1234,
+      Seq("https://github.com/allenai/parsers.git", "git@github.com:schmmd/common.git")
+    )
+    version.commitUrl shouldBe
+      Some("http://github.com/allenai/parsers/commit/e0d972e185bd12b94dedd38834fea150a68f064e")
+  }
+}
+
+class VersionSpec extends UnitSpec {
+  "Version" should "be backwards compatible for reading" in {
+    val json = """{
+      "git":"0144af4325992689cf5fd6d0e3c2d744b25935d6",
+      "artifact":"2014.07.21-0-SNAPSHOT","commitDate":1412094251000
+    }"""
+    json.parseJson.convertTo[Version] shouldBe
+      Version(
+        GitVersion("0144af4325992689cf5fd6d0e3c2d744b25935d6", 1412094251000L, None),
+        "2014.07.21-0-SNAPSHOT",
+        None
+      )
+  }
+
+  "fromResources" should "find common-core's resources" in {
+    // No asserts; this will throw an exception if it's unfound.
+    Version.fromResources("org.allenai.common", "common-core")
+  }
+
+  it should "find a resource using a class loader" in {
+    val expectedVersion = Version(
+      GitVersion("sha123", 123456789L, None),
+      "1.0.0",
+      None
+    )
+    val classpath = Paths.get("src/test/resources/fakejar").toAbsolutePath.toUri.toURL
+    val version = Version.fromResources(
+      "org.fakeorg",
+      "project-name",
+      new URLClassLoader(Array(classpath))
+    )
+    version shouldBe expectedVersion
+  }
+}

--- a/core/src/test/scala/org/allenai/common/json/PackedJsonFormatSpec.scala
+++ b/core/src/test/scala/org/allenai/common/json/PackedJsonFormatSpec.scala
@@ -5,8 +5,6 @@ import org.allenai.common.testkit.UnitSpec
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
-import scala.util.{ Failure, Success, Try }
-
 class PackedJsonFormatSpec extends UnitSpec {
 
   sealed trait Super

--- a/core/src/test/scala/org/allenai/common/json/RichJsObjectSpec.scala
+++ b/core/src/test/scala/org/allenai/common/json/RichJsObjectSpec.scala
@@ -5,8 +5,6 @@ import org.allenai.common.testkit.UnitSpec
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
-import scala.util.{ Failure, Success, Try }
-
 // scalastyle:off magic.number
 class RichJsObjectSpec extends UnitSpec {
 

--- a/guice/src/main/scala/org/allenai/common/guice/ConfigModule.scala
+++ b/guice/src/main/scala/org/allenai/common/guice/ConfigModule.scala
@@ -1,5 +1,6 @@
 package org.allenai.common.guice
 
+import org.allenai.common.Compat.JavaConverters._
 import org.allenai.common.Logging
 import org.allenai.common.Config._
 
@@ -14,7 +15,6 @@ import com.typesafe.config.{
 }
 import net.codingwell.scalaguice.ScalaModule
 
-import scala.collection.JavaConverters._
 import scala.util.Try
 
 /** Parent class for modules which use a typesafe config for values. This automatically binds all

--- a/guice/src/test/scala/org/allenai/common/guice/ConfigModuleSpec.scala
+++ b/guice/src/test/scala/org/allenai/common/guice/ConfigModuleSpec.scala
@@ -229,7 +229,7 @@ class ConfigModuleSpec extends UnitSpec {
 
     val injector = Guice.createInjector(testModule)
 
-    val instance = injector.getInstance(classOf[DottedKeys])
+    injector.getInstance(classOf[DottedKeys])
   }
 
   it should "handle sequences" in {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
+
+addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "3.0.0")


### PR DESCRIPTION
Turns out this is still used by S2 online 😅  We never bumped the common version in scholar, so it went unnoticed.

The VersionInjectorPlugin in `sbt-plugins` is so sneaky. Took me a while to figure out how these tests _ever_ passed because they reference files that just do not exist. Turns out the plugin generates them at runtime, so I added that back.

While I was in here, I also:

- Enabled `fatal-warnings` and fixed a few.
- Fixed compat issue between 2.11/2.12 and 2.13 (not sure why these weren't caught earlier??)
