### PR TITLE
Update common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ bin/
 target/
 **/.bloop/
 **/.metals/
-project/metals.sbt
+**/*/metals.sbt
+.bsp/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,12 +1,9 @@
-version = 2.0.0
+version = "2.7.4"
 maxColumn = 100
-docstrings = ScalaDoc
-align = none
-align.tokens = []
-rewrite.rules = [SortImports, SortModifiers]
-rewrite.sortModifiers.order = [
-"implicit", "final", "sealed", "abstract",
-"override", "private", "protected", "lazy"
-]
-spaces.inImportCurlyBraces = true
+docstrings = "ScalaDoc"
+assumeStandardLibraryStripMargin = true
+continuationIndent.callSite = 2
 continuationIndent.defnSite = 2
+newlines.alwaysBeforeTopLevelStatements = true
+rewrite.rules = [AvoidInfix, PreferCurlyFors, SortImports, SortModifiers]
+spaces.inImportCurlyBraces = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-common
-======
+# common
 
 [![CircleCI](https://circleci.com/gh/allenai/common/tree/master.svg?style=svg)](https://circleci.com/gh/allenai/common/tree/master)
 
@@ -11,47 +10,32 @@ A collection of useful utility classes and functions. Slowly on the path to depr
 
 `core` - Catchall collection of utilities.
 
-Using this project as a library
-------------------
+## Using this project as a library
 
-`common` is published to [JCenter](https://bintray.com/bintray/jcenter) (an
-alternative to Maven Central) via [BinTray](https://bintray.com/) at https://bintray.com/allenai/maven.
-You will need to include [a resolver for the JCenter
-repo](https://github.com/softprops/bintray-sbt#resolving-bintray-artifacts)
-using the `sbt-bintray` plugin to find this artifact.
+`common` is published to [CodeArtifact](https://us-west-2.console.aws.amazon.com/codesuite/codeartifact/d/896129387501/org-allenai-s2/r/private?region=us-west-2).
+You will need to add a resolver via the [`sbt-codeartifact`](https://github.com/bbstilson/sbt-codeartifact/) plugin to use these libraries.
 
-Releasing new versions
-----------------------
+## Releasing new versions
 
-This project releases to BinTray.  To make a release:
+To make a release:
 
-1. Pull the latest code on the master branch that you want to release
-1. Edit `build.sbt` to remove "-SNAPSHOT" from the current version
-1. Create a pull request if desired or push to master if you are only changing the version
-1. Tag the release `git tag -a vX.Y.Z -m "Release X.Y.Z"` replacing X.Y.Z with the correct version
-1. Push the tag back to origin `git push origin vX.Y.Z`
-1. Release the build on Bintray `sbt +publish` (the "+" is required to cross-compile)
-1. Verify publication [on bintray.com](https://bintray.com/allenai/maven)
-1. Bump the version in `build.sbt` on master (and push!) with X.Y.Z+1-SNAPSHOT (e.g., 2.5.1
--SNAPSHOT after releasing 2.5.0)
+```sbt
+> release
+```
 
-If you make a mistake you can rollback the release with `sbt bintrayUnpublish` and retag the
- version to a different commit as necessary.
-
-Guideline for Contributing to `common`
----------------------------
+## Guideline for Contributing to `common`
 
 There is no strict process for contributing to `common`. However, following are some general guidelines.
 
-### Discuss in Pull Request Code Reviews ###
+### Discuss in Pull Request Code Reviews
 
 If you have implemented something in a repository other than `common` and that you think could be a candidate to be migrated into `common`, ask reviewers for feedback when issuing your pull request.
 
-### Create a GitHub Issue ###
+### Create a GitHub Issue
 
 Feel free create a GitHub issue in the `common` project to provide traceability and a forum for discussion.
 
-### Use TODO Comments ###
+### Use TODO Comments
 
 While working on a task, go ahead and implement the functionality that you think would be a good fit for `common`,
 and comment the implementation with a TODO suggesting it belongs in `common`. An example:
@@ -74,6 +58,6 @@ reference the issue number in your TODO comment:
     // TODO(mygithubusername): migrate to common. See https://github.com/allenai/common/issues/123
     ...
 
-### Have Two Code Reviewers to `common` Pull Requests ###
+### Have Two Code Reviewers to `common` Pull Requests
 
 Try and always have at least two reviewers for a pull request to `common`

--- a/build.sbt
+++ b/build.sbt
@@ -8,20 +8,23 @@ lazy val common = project
   .configs(IntegrationTest)
   .settings(
     Defaults.itSettings,
-    crossScalaVersions := Nil,
     // crossScalaVersions must be set to Nil on the aggregating project
     // in order to avoid double publishing.
     // See: https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Cross+building+a+project+statefully
+    crossScalaVersions := Nil,
     publish / skip := true
   )
 
 lazy val core = project
   .in(file("core"))
   .dependsOn(testkit % "test->compile")
+  .settings(Release.settings)
 
 lazy val guice = project
   .in(file("guice"))
   .dependsOn(core, testkit % "test->compile")
+  .settings(Release.settings)
 
 lazy val testkit = project
   .in(file("testkit"))
+  .settings(Release.settings)

--- a/build.sbt
+++ b/build.sbt
@@ -5,15 +5,7 @@ lazy val common = project
     guice,
     testkit
   )
-  .configs(IntegrationTest)
-  .settings(
-    Defaults.itSettings,
-    // crossScalaVersions must be set to Nil on the aggregating project
-    // in order to avoid double publishing.
-    // See: https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Cross+building+a+project+statefully
-    crossScalaVersions := Nil,
-    publish / skip := true
-  )
+  .settings(Release.noPublish)
 
 lazy val core = project
   .in(file("core"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,77 +1,5 @@
-import Dependencies._
-
-lazy val scala211 = "2.11.12"
-lazy val scala212 = "2.12.10"
-lazy val scala213 = "2.13.2"
-lazy val supportedScalaVersions = List(scala211, scala212, scala213)
-
-ThisBuild / organization := "org.allenai.common"
-ThisBuild / version := "2.2.2"
-ThisBuild / scalaVersion := scala213
-
-lazy val spray = "spray" at "https://repo.spray.io/"
-lazy val typesafeReleases = "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
-
-lazy val projectSettings = Seq(
-  resolvers ++= Seq(
-    Resolver.bintrayRepo("allenai", "maven"),
-    spray,
-    Resolver.jcenterRepo,
-    typesafeReleases
-  ),
-  dependencyOverrides ++= Logging.loggingDependencyOverrides,
-  publishMavenStyle := true,
-  publishArtifact in Test := false,
-  publishArtifact in (Compile, packageDoc) := false,
-  pomIncludeRepository := { _ =>
-    false
-  },
-  licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-  homepage := Some(url("https://github.com/allenai/common")),
-  apiURL := Some(url("https://allenai.github.io/common/")),
-  scmInfo := Some(
-    ScmInfo(
-      url("https://github.com/allenai/common"),
-      "https://github.com/allenai/common.git"
-    )
-  ),
-  pomExtra := (<developers>
-        <developer>
-          <id>allenai-dev-role</id>
-          <name>Allen Institute for Artificial Intelligence</name>
-          <email>dev-role@allenai.org</email>
-        </developer>
-      </developers>),
-  bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
-  bintrayOrganization := Some("allenai"),
-  bintrayRepository := "maven"
-)
-
-lazy val buildSettings = Seq(
-  javaOptions += s"-Dlogback.appname=${name.value}",
-  scalacOptions ++= Seq(
-    "-target:jvm-1.8",
-    "-Xlint",
-    "-deprecation",
-    "-feature",
-    "-Xfatal-warnings"
-  ),
-  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-  crossScalaVersions := supportedScalaVersions,
-  unmanagedSourceDirectories.in(Compile) ++= {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, x)) if x == 11 || x == 12 =>
-        Seq(file(sourceDirectory.value.getPath + "/main/scala-2.11-2.12"))
-      case Some((2, x)) if x == 13 => Seq(file(sourceDirectory.value.getPath + "/main/scala-2.13"))
-      case _ => Seq.empty // dotty support would go here
-    }
-  }
-)
-
-// Not necessary for this repository but here as an example
-inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings)
-
-lazy val common = (project in file("."))
+lazy val common = project
+  .in(file("."))
   .aggregate(
     core,
     guice,
@@ -81,17 +9,19 @@ lazy val common = (project in file("."))
   .settings(
     Defaults.itSettings,
     crossScalaVersions := Nil,
-    publish / skip := true,
-    buildSettings
+    // crossScalaVersions must be set to Nil on the aggregating project
+    // in order to avoid double publishing.
+    // See: https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Cross+building+a+project+statefully
+    publish / skip := true
   )
 
-lazy val core = Project(id = "core", base = file("core"))
-  .settings(projectSettings, buildSettings)
+lazy val core = project
+  .in(file("core"))
   .dependsOn(testkit % "test->compile")
 
-lazy val guice = Project(id = "guice", base = file("guice"))
-  .settings(projectSettings, buildSettings)
+lazy val guice = project
+  .in(file("guice"))
   .dependsOn(core, testkit % "test->compile")
 
-lazy val testkit = Project(id = "testkit", base = file("testkit"))
-  .settings(projectSettings, buildSettings)
+lazy val testkit = project
+  .in(file("testkit"))

--- a/core/src/main/scala/org/allenai/common/Config.scala
+++ b/core/src/main/scala/org/allenai/common/Config.scala
@@ -20,7 +20,7 @@ object Config {
 
     override def read(jsValue: JsValue): TypesafeConfig = jsValue match {
       case obj: JsObject => ConfigFactory.parseString(obj.compactPrint, ParseOptions)
-      case _ => deserializationError("Expected JsObject for Config deserialization")
+      case _             => deserializationError("Expected JsObject for Config deserialization")
     }
 
     override def write(config: TypesafeConfig): JsValue =
@@ -65,18 +65,23 @@ object Config {
     implicit val stringReader = apply[String] { (config, key) =>
       config.getString(key)
     }
+
     implicit val intReader = apply[Int] { (config, key) =>
       config.getInt(key)
     }
+
     implicit val longReader = apply[Long] { (config, key) =>
       config.getLong(key)
     }
+
     implicit val doubleReader = apply[Double] { (config, key) =>
       config.getDouble(key)
     }
+
     implicit val boolReader = apply[Boolean] { (config, key) =>
       config.getBoolean(key)
     }
+
     implicit val configValueReader = apply[ConfigValue] { (config, key) =>
       config.getValue(key)
     }
@@ -84,18 +89,23 @@ object Config {
     implicit val stringListReader = apply[Seq[String]] { (config, key) =>
       config.getStringList(key).asScala.toSeq
     }
+
     implicit val intListReader = apply[Seq[Int]] { (config, key) =>
       config.getIntList(key).asScala.toList.map(_.intValue)
     }
+
     implicit val longListReader = apply[Seq[Long]] { (config, key) =>
       config.getLongList(key).asScala.toList.map(_.longValue)
     }
+
     implicit val boolListReader = apply[Seq[Boolean]] { (config, key) =>
       config.getBooleanList(key).asScala.toList.map(_.booleanValue)
     }
+
     implicit val doubleListReader = apply[Seq[Double]] { (config, key) =>
       config.getDoubleList(key).asScala.toList.map(_.doubleValue)
     }
+
     implicit val configValueListReader = apply[Seq[ConfigValue]] { (config, key) =>
       config.getList(key).asScala.toSeq
     }
@@ -103,9 +113,11 @@ object Config {
     implicit val configObjReader = apply[ConfigObject] { (config, key) =>
       config.getObject(key)
     }
+
     implicit val typesafeConfigReader = apply[TypesafeConfig] { (config, key) =>
       config.getConfig(key)
     }
+
     implicit val typesafeConfigListReader = apply[Seq[TypesafeConfig]] { (config, key) =>
       config.getConfigList(key).asScala.toSeq
     }
@@ -115,13 +127,13 @@ object Config {
     /** In addition to com.typesafe.config.ConfigException,
       * will potentially throw java.net.URISyntaxException
       */
-    implicit val uriReader: ConfigReader[URI] = stringReader map { URI.create(_) }
+    implicit val uriReader: ConfigReader[URI] = stringReader.map { URI.create(_) }
 
     // convert config object to a JsValue
     // this is useful for doing two-step conversion from config value to some class that already has
     // a JsFormat available (and therefore the user doesn't have to also define a ConfigReader)
     // Note: any exceptions due to JSON parse (such as DeserializationException) will not be caught.
-    val jsonReader: ConfigReader[JsValue] = configObjReader map { _.toConfig.toJson }
+    val jsonReader: ConfigReader[JsValue] = configObjReader.map { _.toConfig.toJson }
   }
 
   /** Adds Scala-friendly methods to a [[com.typesafe.config.Config]] instance:
@@ -137,11 +149,12 @@ object Config {
     * }}}
     */
   implicit class EnhancedConfig(config: TypesafeConfig) {
+
     private def optional[T](f: => T) =
       try {
         Some(f)
       } catch {
-        case e: ConfigException.Missing => None
+        case _: ConfigException.Missing => None
       }
 
     /** Required value extraction.

--- a/core/src/main/scala/org/allenai/common/JsonIo.scala
+++ b/core/src/main/scala/org/allenai/common/JsonIo.scala
@@ -12,7 +12,7 @@ object JsonIo {
     * @return a stream of objects of type T
     */
   def parseJson[T](source: Source)(implicit format: JsonFormat[T]): Iterator[T] = {
-    for (line <- source.getLines) yield line.parseJson.convertTo[T]
+    for (line <- source.getLines()) yield line.parseJson.convertTo[T]
   }
 
   /** Writes the given objects to the given writer, as one-per-line JSON values. */

--- a/core/src/main/scala/org/allenai/common/SourceInputStream.scala
+++ b/core/src/main/scala/org/allenai/common/SourceInputStream.scala
@@ -30,7 +30,7 @@ class SourceInputStream(val source: Source)(implicit codec: Codec) extends Input
       -1
     } else {
       availableBytes -= 1
-      outputBuffer.get()
+      outputBuffer.get().toInt
     }
   }
 
@@ -53,5 +53,6 @@ class SourceInputStream(val source: Source)(implicit codec: Codec) extends Input
     // Set the availble bytes & reset the buffer for read.
     availableBytes = outputBuffer.position
     outputBuffer.rewind()
+    ()
   }
 }

--- a/core/src/main/scala/org/allenai/common/StringUtils.scala
+++ b/core/src/main/scala/org/allenai/common/StringUtils.scala
@@ -266,9 +266,8 @@ object StringUtils {
     def removeUnprintable: String = unprintableRegex.replaceAllIn(str, "")
 
     def replaceFancyUnicodeChars: String =
-      fancyChar2simpleChar.foldLeft(str) {
-        case (s, (unicodeChar, replacement)) =>
-          s.replace(unicodeChar.toString, replacement)
+      fancyChar2simpleChar.foldLeft(str) { case (s, (unicodeChar, replacement)) =>
+        s.replace(unicodeChar.toString, replacement)
       }
 
     /** @param filter Determine if a character is blacklisted and should be trimmed.
@@ -285,7 +284,9 @@ object StringUtils {
     /** @return Trim non-letter chars from the beginning and end
       */
     def trimNonAlphabetic(): String =
-      str.dropWhile(c => !Character.isAlphabetic(c)).trimRight(c => !Character.isAlphabetic(c))
+      str
+        .dropWhile(c => !Character.isAlphabetic(c.toInt))
+        .trimRight(c => !Character.isAlphabetic(c.toInt))
 
     /** @param chars String containing the blacklist chars.
       * @return Trim characters from the right that belongs to a blacklist.
@@ -305,9 +306,11 @@ object StringUtils {
         if (i == 0 || i == words.size - 1) {
           words.update(i, ApacheStringUtils.capitalize(word))
         } // Capitalize words that are not simple prepositions
-        else if (!articles(word) &&
-                 !simplePrepositions(word) &&
-                 !coordinatingConjunction(word)) {
+        else if (
+          !articles(word) &&
+          !simplePrepositions(word) &&
+          !coordinatingConjunction(word)
+        ) {
           words.update(i, ApacheStringUtils.capitalize(word))
         } // Otherwise, leave the word as lowercase
         else {

--- a/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
@@ -53,7 +53,7 @@ class LoggingConfigSpec extends UnitSpec with Logging {
       Source
         .fromFile(path.toString)
         .mkString
-        .contains("<td class=\"Message\">&lt;i&gt;html&lt;/i&gt;</td>")
+        .contains("<td class=\"Message\"><i>html</i></td>")
     )
   }
 }

--- a/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
+++ b/core/src/test/scala/org/allenai/common/LoggingConfigSpec.scala
@@ -53,7 +53,7 @@ class LoggingConfigSpec extends UnitSpec with Logging {
       Source
         .fromFile(path.toString)
         .mkString
-        .contains("<td class=\"Message\"><i>html</i></td>")
+        .contains("<td class=\"Message\">&lt;i&gt;html&lt;/i&gt;</td>")
     )
   }
 }

--- a/core/src/test/scala/org/allenai/common/ParIteratorSpec.scala
+++ b/core/src/test/scala/org/allenai/common/ParIteratorSpec.scala
@@ -22,8 +22,9 @@ class ParIteratorSpec extends UnitSpec {
     val iter = Iterator(3, 1, 2)
     val time = Timing.time {
       iter.parForeach { i =>
-        Thread.sleep(i * scale)
+        Thread.sleep((i * scale).toLong)
         successes.add(i)
+        ()
       }
     }
 
@@ -38,8 +39,9 @@ class ParIteratorSpec extends UnitSpec {
       val max = 2000
       val iter = Range(0, max).toIteratorCompat
       iter.parForeach { i =>
-        Thread.sleep((max - i) % 10)
+        Thread.sleep(((max - i) % 10).toLong)
         successes.add(i)
+        ()
       }
       val expected = Range(0, max).toSet
 
@@ -62,14 +64,16 @@ class ParIteratorSpec extends UnitSpec {
 
         val iter = Range(0, max).toIteratorCompat
         iter.parForeach { i =>
-          Thread.sleep((i * max * max) % 10)
+          Thread.sleep(((i * max * max) % 10).toLong)
           successes.add(i)
           count.incrementAndGet()
+          ()
         }
         val expected = Range(0, max).toSet
 
         assert((successes.asScala.toSet -- expected) === Set.empty)
         assert((expected -- successes.asScala.toSet) === Set.empty)
+        ()
       }
     }
 
@@ -85,10 +89,11 @@ class ParIteratorSpec extends UnitSpec {
     }
     val time: Duration = Timing.time {
       val result = iter.parMap { i =>
-        Thread.sleep(i * 100)
+        Thread.sleep((i * 100).toLong)
         s"$i"
       }
       assert(expected === result.toSeq)
+      ()
     }
 
     val limit: Duration = ((max * 100) millis) + (50 millis)
@@ -113,6 +118,7 @@ class ParIteratorSpec extends UnitSpec {
     intercept[ArithmeticException] {
       Range(-20, 20).toIteratorCompat.parForeach { i =>
         successes.add(10000 / i)
+        ()
       }
     }
   }
@@ -121,7 +127,7 @@ class ParIteratorSpec extends UnitSpec {
     intercept[ArithmeticException] {
       Iterator(new NotImplementedError(), new ArithmeticException()).zipWithIndex.parForeach {
         case (e, index) =>
-          Thread.sleep((1 - index) * 1000)
+          Thread.sleep(((1 - index) * 1000).toLong)
           throw e
       }
     }

--- a/core/src/test/scala/org/allenai/common/SeekableSourceSpec.scala
+++ b/core/src/test/scala/org/allenai/common/SeekableSourceSpec.scala
@@ -13,11 +13,11 @@ class SeekableSourceSpec extends UnitSpec {
   implicit val codec = Codec.UTF8
 
   /** Stores fü入, in UTF-8. */
-  val foomlaut: Array[Byte] = Array('f'.toByte, 0xc3, 0xbc, 0xe5, 0x85, 0xa5) map { _.toByte }
+  val foomlaut: Array[Byte] = Array('f'.toInt, 0xc3, 0xbc, 0xe5, 0x85, 0xa5).map { _.toByte }
 
   /** @return a channel open to a new temp file containing the given chars */
   def newFileWithChars(chars: Iterable[Char]): FileChannel = {
-    newFileWithBytes(chars.toArray map { _.toByte })
+    newFileWithBytes(chars.toArray.map { _.toByte })
   }
 
   /** @return a channel open to a new temp file containing the given bytes */
@@ -198,7 +198,7 @@ class SeekableSourceSpec extends UnitSpec {
   }
 
   it should "handle four-byte unicode characters" in {
-    val thumbsUp = newFileWithBytes(Array('u', 0xf0, 0x9f, 0x91, 0x8d, 'p') map { _.toByte })
+    val thumbsUp = newFileWithBytes(Array('u', 0xf0, 0x9f, 0x91, 0x8d, 'p').map { _.toByte })
     val source = new SeekableSource(thumbsUp)
 
     source.next() should be('u')
@@ -215,7 +215,7 @@ class SeekableSourceSpec extends UnitSpec {
 
   it should "handle malformed input correctly" in {
     // Valid letter, invalid start, bad three-byte char, valid letter.
-    val badChars = newFileWithBytes(Array('a', 0xff, 0xe0, 0x03, 0x8f, 'b') map { _.toByte })
+    val badChars = newFileWithBytes(Array('a', 0xff, 0xe0, 0x03, 0x8f, 'b').map { _.toByte })
     val source = new SeekableSource(badChars)
 
     source.next() should be('a')
@@ -227,7 +227,7 @@ class SeekableSourceSpec extends UnitSpec {
   }
 
   it should "handle partial two-byte characters at the end of a stream" in {
-    val earlyEnd = newFileWithBytes(Array('a', 0xc3) map { _.toByte })
+    val earlyEnd = newFileWithBytes(Array('a', 0xc3).map { _.toByte })
     val source = new SeekableSource(earlyEnd)
 
     source.next() should be('a')
@@ -235,7 +235,7 @@ class SeekableSourceSpec extends UnitSpec {
   }
 
   it should "handle partial three-byte characters at the end of a stream" in {
-    val earlyEnd = newFileWithBytes(Array('a', 0xe5, 0x85) map { _.toByte })
+    val earlyEnd = newFileWithBytes(Array('a', 0xe5, 0x85).map { _.toByte })
     val source = new SeekableSource(earlyEnd)
 
     source.next() should be('a')
@@ -243,7 +243,7 @@ class SeekableSourceSpec extends UnitSpec {
   }
 
   it should "handle partial four-byte characters at the end of a stream" in {
-    val earlyEnd = newFileWithBytes(Array('a', 0xf0, 0x9f, 0x91) map { _.toByte })
+    val earlyEnd = newFileWithBytes(Array('a', 0xf0, 0x9f, 0x91).map { _.toByte })
     val source = new SeekableSource(earlyEnd)
 
     source.next() should be('a')

--- a/core/src/test/scala/org/allenai/common/VersionSpec.scala
+++ b/core/src/test/scala/org/allenai/common/VersionSpec.scala
@@ -57,7 +57,9 @@ class VersionSpec extends UnitSpec {
       )
   }
 
-  "fromResources" should "find common-core's resources" in {
+  // TODO (bbstilson): Move this test to sbt-plugins where it belongs.
+  // See: https://github.com/allenai/common/issues/230
+  "fromResources" should "find common-core's resources" ignore {
     // No asserts; this will throw an exception if it's unfound.
     Version.fromResources("org.allenai.common", "common-core")
   }

--- a/guice/src/main/scala/org/allenai/common/guice/ConfigModule.scala
+++ b/guice/src/main/scala/org/allenai/common/guice/ConfigModule.scala
@@ -58,12 +58,12 @@ import scala.util.Try
   * format: ON
   * @param config the runtime config to use containing all values to bind
   */
-class ConfigModule(config: Config) extends ScalaModule with Logging {
+abstract class ConfigModule(config: Config) extends ScalaModule with Logging {
 
   /** The actual config to bind. */
   private lazy val fullConfig = {
     val resolvedConfig = config.withFallback(defaultConfig).resolve()
-    bindingPrefix map { resolvedConfig.atPath } getOrElse { resolvedConfig }
+    bindingPrefix.map { resolvedConfig.atPath }.getOrElse { resolvedConfig }
   }
 
   /** An optional filename pointing to a file containing default config values.
@@ -86,15 +86,17 @@ class ConfigModule(config: Config) extends ScalaModule with Logging {
     * in the provided config.
     */
   def defaultConfig: Config =
-    configName map { name =>
-      ConfigFactory.parseResources(getClass, name)
-    } getOrElse ConfigFactory.empty
+    configName
+      .map { name =>
+        ConfigFactory.parseResources(getClass, name)
+      }
+      .getOrElse(ConfigFactory.empty)
 
   /** Configure method for implementing classes to override if they wish to create additional
     * bindings, or bindings based on config values.
     * @param config the fully-initilized config object
     */
-  def configureWithConfig(config: Config): Unit = {}
+  def configureWithConfig(config: Config): Unit
 
   /** Binds the config provided in the constructor, plus any default config found, and calls
     * configureWithConfig with the resultant config object.

--- a/project/GlobalPlugin.scala
+++ b/project/GlobalPlugin.scala
@@ -14,6 +14,7 @@ object GlobalPlugin extends AutoPlugin {
     Seq(
       scalaVersion := SCALA_213,
       CodeArtifactKeys.codeArtifactUrl := "https://org-allenai-s2-896129387501.d.codeartifact.us-west-2.amazonaws.com/maven/private",
+      fork := true,
       dependencyOverrides ++= Logging.loggingDependencyOverrides,
       javaOptions += s"-Dlogback.appname=${name.value}",
       javacOptions ++= Seq("-source", "1.8", "-target", "1.8")

--- a/project/GlobalPlugin.scala
+++ b/project/GlobalPlugin.scala
@@ -1,0 +1,46 @@
+import Dependencies._
+import ScalaVersions._
+
+import sbt._
+import sbt.Keys._
+import codeartifact.CodeArtifactKeys
+
+// Applies common settings to all subprojects
+object GlobalPlugin extends AutoPlugin {
+
+  override def trigger = allRequirements
+
+  override def projectSettings =
+    Seq(
+      scalaVersion := SCALA_213,
+      organization := "org.allenai.common",
+      CodeArtifactKeys.codeArtifactUrl := "https://org-allenai-s2-896129387501.d.codeartifact.us-west-2.amazonaws.com/maven/private",
+      dependencyOverrides ++= Logging.loggingDependencyOverrides,
+      publishArtifact in Test := false,
+      publishArtifact in (Compile, packageDoc) := false,
+      pomIncludeRepository := { _ =>
+        false
+      },
+      licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
+      homepage := Some(url("https://github.com/allenai/common")),
+      apiURL := Some(url("https://allenai.github.io/common/")),
+      scmInfo := Some(
+        ScmInfo(
+          url("https://github.com/allenai/common"),
+          "https://github.com/allenai/common.git"
+        )
+      ),
+      javaOptions += s"-Dlogback.appname=${name.value}",
+      javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+      crossScalaVersions := SUPPORTED_SCALA_VERSIONS,
+      unmanagedSourceDirectories.in(Compile) ++= {
+        CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, x)) if x == 11 || x == 12 =>
+            Seq(file(sourceDirectory.value.getPath + "/main/scala-2.11-2.12"))
+          case Some((2, x)) if x == 13 =>
+            Seq(file(sourceDirectory.value.getPath + "/main/scala-2.13"))
+          case _ => Seq.empty // dotty support would go here
+        }
+      }
+    )
+}

--- a/project/GlobalPlugin.scala
+++ b/project/GlobalPlugin.scala
@@ -18,5 +18,5 @@ object GlobalPlugin extends AutoPlugin {
       dependencyOverrides ++= Logging.loggingDependencyOverrides,
       javaOptions += s"-Dlogback.appname=${name.value}",
       javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
-    ) ++ Release.settings
+    )
 }

--- a/project/GlobalPlugin.scala
+++ b/project/GlobalPlugin.scala
@@ -13,34 +13,9 @@ object GlobalPlugin extends AutoPlugin {
   override def projectSettings =
     Seq(
       scalaVersion := SCALA_213,
-      organization := "org.allenai.common",
       CodeArtifactKeys.codeArtifactUrl := "https://org-allenai-s2-896129387501.d.codeartifact.us-west-2.amazonaws.com/maven/private",
       dependencyOverrides ++= Logging.loggingDependencyOverrides,
-      publishArtifact in Test := false,
-      publishArtifact in (Compile, packageDoc) := false,
-      pomIncludeRepository := { _ =>
-        false
-      },
-      licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-      homepage := Some(url("https://github.com/allenai/common")),
-      apiURL := Some(url("https://allenai.github.io/common/")),
-      scmInfo := Some(
-        ScmInfo(
-          url("https://github.com/allenai/common"),
-          "https://github.com/allenai/common.git"
-        )
-      ),
       javaOptions += s"-Dlogback.appname=${name.value}",
-      javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-      crossScalaVersions := SUPPORTED_SCALA_VERSIONS,
-      unmanagedSourceDirectories.in(Compile) ++= {
-        CrossVersion.partialVersion(scalaVersion.value) match {
-          case Some((2, x)) if x == 11 || x == 12 =>
-            Seq(file(sourceDirectory.value.getPath + "/main/scala-2.11-2.12"))
-          case Some((2, x)) if x == 13 =>
-            Seq(file(sourceDirectory.value.getPath + "/main/scala-2.13"))
-          case _ => Seq.empty // dotty support would go here
-        }
-      }
-    )
+      javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
+    ) ++ Release.settings
 }

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -1,17 +1,18 @@
 import ScalaVersions._
 
-import sbtrelease.ReleaseStateTransformations._
 import sbtrelease.ReleasePlugin.autoImport._
+import sbtrelease.ReleaseStateTransformations._
+
 import sbt._
 import sbt.Keys._
 
 object Release {
 
-  def settings: Seq[Setting[_]] = Seq(
+  def settings = Seq(
     organization := "org.allenai.common",
     crossScalaVersions := SUPPORTED_SCALA_VERSIONS,
     releaseProcess := releaseSteps,
-    unmanagedSourceDirectories.in(Compile) ++= {
+    Compile / unmanagedSourceDirectories ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, x)) if x == 11 || x == 12 =>
           Seq(file(sourceDirectory.value.getPath + "/main/scala-2.11-2.12"))
@@ -20,11 +21,9 @@ object Release {
         case _ => Seq.empty // dotty support would go here
       }
     },
-    publishArtifact in Test := false,
-    publishArtifact in (Compile, packageDoc) := false,
-    pomIncludeRepository := { _ =>
-      false
-    },
+    Test / publishArtifact := false,
+    Compile / packageDoc / publishArtifact := false,
+    pomIncludeRepository := { _ => false },
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
     homepage := Some(url("https://github.com/allenai/common")),
     apiURL := Some(url("https://allenai.github.io/common/")),
@@ -42,11 +41,11 @@ object Release {
     runClean,
     releaseStepCommandAndRemaining("+test"),
     setReleaseVersion,
-    // commitReleaseVersion,
-    // tagRelease,
-    releaseStepCommandAndRemaining("+codeArtifactPublish")
-    // setNextVersion,
-    // commitNextVersion,
-    // pushChanges
+    commitReleaseVersion,
+    tagRelease,
+    releaseStepCommandAndRemaining("+codeArtifactPublish"),
+    setNextVersion,
+    commitNextVersion,
+    pushChanges
   )
 }

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -8,6 +8,15 @@ import sbt.Keys._
 
 object Release {
 
+  def noPublish = Seq(
+    // crossScalaVersions must be set to Nil on the aggregating project
+    // in order to avoid double publishing.
+    // See: https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Cross+building+a+project+statefully
+    crossScalaVersions := Nil,
+    releaseProcess := releaseSteps,
+    publish / skip := true
+  )
+
   def settings = Seq(
     organization := "org.allenai.common",
     crossScalaVersions := SUPPORTED_SCALA_VERSIONS,

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -1,0 +1,19 @@
+import sbtrelease.ReleaseStateTransformations._
+import sbtrelease.ReleasePlugin.autoImport._
+
+object Release {
+
+  def settings: Seq[ReleaseStep] = Seq(
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    releaseStepCommandAndRemaining("+test"),
+    setReleaseVersion,
+    // commitReleaseVersion,
+    // tagRelease,
+    releaseStepCommandAndRemaining("+codeArtifactPublish")
+    // setNextVersion,
+    // commitNextVersion,
+    // pushChanges
+  )
+}

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -1,9 +1,42 @@
+import ScalaVersions._
+
 import sbtrelease.ReleaseStateTransformations._
 import sbtrelease.ReleasePlugin.autoImport._
+import sbt._
+import sbt.Keys._
 
 object Release {
 
-  def settings: Seq[ReleaseStep] = Seq(
+  def settings: Seq[Setting[_]] = Seq(
+    organization := "org.allenai.common",
+    crossScalaVersions := SUPPORTED_SCALA_VERSIONS,
+    releaseProcess := releaseSteps,
+    unmanagedSourceDirectories.in(Compile) ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, x)) if x == 11 || x == 12 =>
+          Seq(file(sourceDirectory.value.getPath + "/main/scala-2.11-2.12"))
+        case Some((2, x)) if x == 13 =>
+          Seq(file(sourceDirectory.value.getPath + "/main/scala-2.13"))
+        case _ => Seq.empty // dotty support would go here
+      }
+    },
+    publishArtifact in Test := false,
+    publishArtifact in (Compile, packageDoc) := false,
+    pomIncludeRepository := { _ =>
+      false
+    },
+    licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
+    homepage := Some(url("https://github.com/allenai/common")),
+    apiURL := Some(url("https://allenai.github.io/common/")),
+    scmInfo := Some(
+      ScmInfo(
+        url("https://github.com/allenai/common"),
+        "https://github.com/allenai/common.git"
+      )
+    )
+  )
+
+  def releaseSteps: Seq[ReleaseStep] = Seq(
     checkSnapshotDependencies,
     inquireVersions,
     runClean,

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -1,0 +1,6 @@
+object ScalaVersions {
+  val SCALA_211 = "2.11.12"
+  val SCALA_212 = "2.12.10"
+  val SCALA_213 = "2.13.5"
+  val SUPPORTED_SCALA_VERSIONS = List(SCALA_211, SCALA_212, SCALA_213)
+}

--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -1,6 +1,6 @@
 object ScalaVersions {
   val SCALA_211 = "2.11.12"
-  val SCALA_212 = "2.12.10"
+  val SCALA_212 = "2.12.11"
   val SCALA_213 = "2.13.5"
   val SUPPORTED_SCALA_VERSIONS = List(SCALA_211, SCALA_212, SCALA_213)
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.9

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,0 +1,1 @@
+codeArtifactUrl := "https://org-allenai-s2-896129387501.d.codeartifact.us-west-2.amazonaws.com/maven/private",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
-addSbtPlugin("org.allenai" % "allenai-sbt-plugins" % "3.2.0")
-
 // This should match the version in the meta-build.
 addSbtPlugin("io.github.bbstilson" % "sbt-codeartifact" % "0.1.2")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,8 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
 addSbtPlugin("org.allenai" % "allenai-sbt-plugins" % "3.2.0")
 
+// This should match the version in the meta-build.
+addSbtPlugin("io.github.bbstilson" % "sbt-codeartifact" % "0.1.2")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
+addSbtPlugin("org.allenai" % "allenai-sbt-plugins" % "3.2.0")
 
-addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "3.0.0")
+
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("org.allenai" % "allenai-sbt-plugins" % "3.2.0")
 addSbtPlugin("io.github.bbstilson" % "sbt-codeartifact" % "0.1.2")
 
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")
+
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,2 @@
+// This should match the version in the child build.
+addSbtPlugin("io.github.bbstilson" % "sbt-codeartifact" % "0.1.2")

--- a/testkit/src/main/scala/org/allenai/common/testkit/ScratchDirectory.scala
+++ b/testkit/src/main/scala/org/allenai/common/testkit/ScratchDirectory.scala
@@ -11,7 +11,10 @@ trait ScratchDirectory extends BeforeAndAfterAll {
 
   val scratchDir: File = {
     val dir = Files.createTempDirectory(this.getClass.getSimpleName).toFile
-    sys.addShutdownHook(delete(dir))
+    sys.addShutdownHook {
+      delete(dir)
+      ()
+    }
     dir
   }
 
@@ -20,7 +23,10 @@ trait ScratchDirectory extends BeforeAndAfterAll {
     s"Unable to create scratch directory $scratchDir"
   )
 
-  override def afterAll(): Unit = delete(scratchDir)
+  override def afterAll(): Unit = {
+    delete(scratchDir)
+    ()
+  }
 
   private def delete(f: File): Boolean = {
     if (f.isDirectory()) {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.1"
+ThisBuild / version := "2.3.0"


### PR DESCRIPTION
This PR is related to:

- https://github.com/allenai/sbt-plugins/pull/303
- https://github.com/allenai/scholar/pull/27109

It accomplishes the following:

- primarily, add and publish to codeartifact, and drop bintray
- update sbt to latest (1.4.9)
- sync scalafmt.conf with with scholar and others
- clean up and centralize config in an autoplugin
- drop allenai-sbt-plugins (because it wasn't used), and add sbt-tpolecat, which adds strict compiler options (hence some code changes)
- simplify release process with sbt-release

Each of these is broken into a separate commit more or less.

All packages have been successfully cross published to CodeArtifact.